### PR TITLE
High resolution foregrounds simulation

### DIFF
--- a/201903_highres_foregrounds/README.md
+++ b/201903_highres_foregrounds/README.md
@@ -12,6 +12,9 @@ Each component is saved separately, all maps are in `uK_CMB`, IQU, single precis
 
 Dust, synchrotron, free-free and anomalous microwave emission using the "0" models, i.e. `SO_d0`, `SO_s0`, `SO_f0`, and `SO_a0`, see more details in [in the documentation](https://so-pysm-models.readthedocs.io/en/0.2.dev/highres_templates.html#details-about-individual-models).
 
+These maps are full-sky, you can get the noise maps from [the `201901_gaussian_fg_lensed_cmb_realistic_noise` simulations](https://github.com/simonsobs/map_based_simulations/tree/master/201901_gaussian_fg_lensed_cmb_realistic_noise) to add noise and apply the cut from the scanning strategy.
+Another option, if you are interested only in the sky cut, is to use the [`SONoiseSimulator` class from `mapsims`](https://mapsims.readthedocs.io/en/latest/api/mapsims.SONoiseSimulator.html#mapsims.SONoiseSimulator), select `nside` and `scanning_strategy` and access the `hitmap` attribute.
+
 ## Available maps
 
 HEALPix maps at high resolution (nside 4096) and low resolution (nside 512), these models are deterministic, so we have

--- a/201903_highres_foregrounds/README.md
+++ b/201903_highres_foregrounds/README.md
@@ -1,0 +1,40 @@
+High resolution foregrounds with spectral index not varying spatially
+=====================================================================
+
+Release date March 2019
+
+The last version of this file is [available on Github](https://github.com/simonsobs/map_based_simulations/tree/master/201903_highres_foregrounds).
+The same folder contains all the configuration files used and the scripts to create SLURM jobs.
+
+## Input components
+
+Each component is saved separately, all maps are in `uK_CMB`, IQU, single precision (`float32`)
+
+Dust, synchrotron, free-free and anomalous microwave emission using the "0" models, i.e. `SO_d0`, `SO_s0`, `SO_f0`, and `SO_a0`, see more details in [in the documentation](https://so-pysm-models.readthedocs.io/en/0.2.dev/highres_templates.html#details-about-individual-models).
+
+## Available maps
+
+HEALPix maps at high resolution (nside 4096) and low resolution (nside 512), these models are deterministic, so we have
+a set for each resolution for all channels.
+
+**Location at NERSC**:
+
+    /project/projectdirs/sobs/v4_sims/mbs/201903_highres_foregrounds
+
+The naming convention is:
+
+    {output_nside}/{content}/{num:04d}/simonsobs_{content}_uKCMB_{telescope}{band:03d}_nside{nside}_{num:04d}.fits"
+
+where:
+
+* `content` is in `[cmb, synchtrotron, freefree, ame]`
+* `num` is `0`
+* `telescope` is `sa` or `la`
+* `band` is the channel frequency in GHz
+
+Backed up to tape in `~zonca/sobs/mbs/201903_highres_foregrounds`.
+
+## Software
+
+* The PySM components are available in the [`so_pysm_models`](https://github.com/simonsobs/so_pysm_models) package, version 0.2.0, see the [documentation](https://so-pysm-models.readthedocs.io/en/0.2.dev)
+* The noise component and the runner script are available in the [`mapsims`](https://github.com/simonsobs/mapsims) package, version 0.2.0, see the [documentation](https://mapsims.readthedocs.io/en/0.2.dev)

--- a/201903_highres_foregrounds/README.md
+++ b/201903_highres_foregrounds/README.md
@@ -37,6 +37,15 @@ where:
 
 Backed up to tape in `~zonca/sobs/mbs/201903_highres_foregrounds`.
 
+## Plots
+
+See the `plot_maps.ipynb` notebook in the folder, executed notebooks:
+
+* [Temperature NSIDE 512](https://gist.github.com/240377264d49c2122c9521e0256b0388)
+* [Temperature NSIDE 4096](https://gist.github.com/zonca/ce3e58f964ff63ddcc4ef8ac8db74205)
+* [Polarization NSIDE 512](https://gist.github.com/25f3947f9d44d88b82e15127441f7bfb)
+* [Polarization NSIDE 4096](https://gist.github.com/zonca/35f5d2ed6ff27e8d2f788258218da47c)
+
 ## Software
 
 * The PySM components are available in the [`so_pysm_models`](https://github.com/simonsobs/so_pysm_models) package, version 0.2.0, see the [documentation](https://so-pysm-models.readthedocs.io/en/0.2.dev)

--- a/201903_highres_foregrounds/README.md
+++ b/201903_highres_foregrounds/README.md
@@ -1,7 +1,7 @@
 High resolution foregrounds with spectral index not varying spatially
 =====================================================================
 
-Release date March 2019
+Release date 25 March 2019
 
 The last version of this file is [available on Github](https://github.com/simonsobs/map_based_simulations/tree/master/201903_highres_foregrounds).
 The same folder contains all the configuration files used and the scripts to create SLURM jobs.

--- a/201903_highres_foregrounds/README.md
+++ b/201903_highres_foregrounds/README.md
@@ -37,6 +37,10 @@ where:
 
 Backed up to tape in `~zonca/sobs/mbs/201903_highres_foregrounds`.
 
+## Issues or feedback
+
+In case of any problem with the maps or the documentation or request more/different runs, [open an issue on the `map_based_simulations` repo](https://github.com/simonsobs/map_based_simulations/issues)
+
 ## Plots
 
 See the `plot_maps.ipynb` notebook in the folder, executed notebooks:

--- a/201903_highres_foregrounds/ame_4096.cfg
+++ b/201903_highres_foregrounds/ame_4096.cfg
@@ -1,0 +1,3 @@
+content = ame
+[pysm_components]
+pysm_components_string = SO_a0s

--- a/201903_highres_foregrounds/ame_512.cfg
+++ b/201903_highres_foregrounds/ame_512.cfg
@@ -1,0 +1,3 @@
+content = ame
+[pysm_components]
+pysm_components_string = SO_a0

--- a/201903_highres_foregrounds/common.cfg
+++ b/201903_highres_foregrounds/common.cfg
@@ -1,0 +1,8 @@
+output_nside = 512
+num = 0000
+output_folder = output/${output_nside}/${content}/$num
+output_filename_template="simonsobs_${content}_uKCMB_{telescope}{band:03d}_nside{nside}_$num.fits"
+channels = all
+unit = uK_CMB
+mapsims_version = "0.2.0"
+so_pysm_models_version = "0.2.0"

--- a/201903_highres_foregrounds/common_4096.cfg
+++ b/201903_highres_foregrounds/common_4096.cfg
@@ -1,0 +1,8 @@
+output_nside = 4096
+num = 0000
+output_folder = output/${output_nside}/${content}/$num
+output_filename_template="simonsobs_${content}_uKCMB_{telescope}{band:03d}_nside{nside}_$num.fits"
+channels = all
+unit = uK_CMB
+mapsims_version = "0.2.0"
+so_pysm_models_version = "0.2.0"

--- a/201903_highres_foregrounds/dust_4096.cfg
+++ b/201903_highres_foregrounds/dust_4096.cfg
@@ -1,0 +1,3 @@
+content = dust
+[pysm_components]
+pysm_components_string = SO_d0s

--- a/201903_highres_foregrounds/dust_512.cfg
+++ b/201903_highres_foregrounds/dust_512.cfg
@@ -1,0 +1,3 @@
+content = dust
+[pysm_components]
+pysm_components_string = SO_d0

--- a/201903_highres_foregrounds/execute.sh
+++ b/201903_highres_foregrounds/execute.sh
@@ -1,0 +1,5 @@
+NSIDE=512
+for cfg in *$NSIDE*.cfg
+do
+    mapsims_run common.cfg $cfg
+done

--- a/201903_highres_foregrounds/freefree_4096.cfg
+++ b/201903_highres_foregrounds/freefree_4096.cfg
@@ -1,0 +1,3 @@
+content = freefree
+[pysm_components]
+pysm_components_string = SO_f0s

--- a/201903_highres_foregrounds/freefree_512.cfg
+++ b/201903_highres_foregrounds/freefree_512.cfg
@@ -1,0 +1,3 @@
+content = freefree
+[pysm_components]
+pysm_components_string = SO_f0

--- a/201903_highres_foregrounds/plot_maps.ipynb
+++ b/201903_highres_foregrounds/plot_maps.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cd /project/projectdirs/sobs/v4_sims/mbs/201903_highres_foregrounds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import healpy as hp\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename_template = \"{nside}/{content}/{num:04d}/simonsobs_{content}_uKCMB_{telescope}{band:03d}_nside{nside}_{num:04d}.fits\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for nside in [512]:\n",
+    "    for content in [\"dust\", \"synchrotron\", \"freefree\", \"ame\"]:\n",
+    "        for band in [27,  39,  93, 145, 225, 280]:\n",
+    "            for telescope in [\"sa\", \"la\"]:\n",
+    "                filename = filename_template.format(nside=nside, content=content, num=0, telescope=telescope, band=band)\n",
+    "                m = hp.read_map(filename, field=0, verbose=False)\n",
+    "                hp.mollview(m, title=\"Temperature \" + filename.split(\".\")[0].split(\"/\")[-1], min=0, max=1e3, unit=\"uK_CMB\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for nside in [512]:\n",
+    "    for content in [\"dust\", \"synchrotron\", \"freefree\", \"ame\"]:\n",
+    "        for band in [27,  39,  93, 145, 225, 280]:\n",
+    "            for telescope in [\"sa\", \"la\"]:\n",
+    "                filename = filename_template.format(nside=nside, content=content, num=0, telescope=telescope, band=band)\n",
+    "                m = hp.read_map(filename, field=(1,2), verbose=False)\n",
+    "                hp.mollview(np.sqrt(m[0]**2+m[1]**2), title=\"Polarization \" + filename.split(\".\")[0].split(\"/\")[-1], min=0, max=1e2, unit=\"uK_CMB\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "condajupynersc",
+   "language": "python",
+   "name": "condajupynersc"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/201903_highres_foregrounds/prepare_cfg.py
+++ b/201903_highres_foregrounds/prepare_cfg.py
@@ -1,0 +1,13 @@
+import configobj
+
+all_simulations = ["dust", "synchrotron", "ame", "freefree"]
+model = "0"
+
+for nside in [512, 4096]:
+    small_scale = "s" if nside > 512 else ""
+    for content in all_simulations:
+        config = configobj.ConfigObj()
+        config["content"] = content
+        config["pysm_components"] = dict(pysm_components_string = "SO_" + content[0] + model + small_scale)
+        config.filename = "{}_{}.cfg".format(content, nside)
+        config.write()

--- a/201903_highres_foregrounds/prepare_slurm_scripts.py
+++ b/201903_highres_foregrounds/prepare_slurm_scripts.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+template = open("submit.slurm").read()
+
+for nside in [4096]:
+    for simulation_type in ["dust", "synchrotron", "freefree", "ame"]:
+        folder = Path(f"output/{nside}/{simulation_type}")
+        folder.mkdir(exist_ok=True)
+        hours = 2
+        minutes = 30
+        with open(folder / "submit.slurm", "w") as f:
+            print("writing", f.name)
+            f.write(template.format(
+                simulation_type=simulation_type,
+                nside=nside,
+                hours=hours,
+                minutes=minutes,
+                channels="all",
+                first_sim_id=0,
+                last_sim_id=0
+            ))

--- a/201903_highres_foregrounds/submit.slurm
+++ b/201903_highres_foregrounds/submit.slurm
@@ -1,0 +1,22 @@
+#!/bin/bash
+#SBATCH --qos=regular
+#SBATCH --time={hours}:{minutes}:00
+#SBATCH --nodes=1
+#SBATCH --job-name=mapsims_{simulation_type}_{nside}
+#SBATCH --constraint=haswell
+#SBATCH --mail-user
+#SBATCH --error=mapsims_{simulation_type}_{nside}_%j.err
+#SBATCH --output=mapsims_{simulation_type}_{nside}_%j.out
+
+NUM=0000
+sim={simulation_type}
+NSIDE={nside}
+CHANNELS={channels}
+template_config_file=common_{nside}.cfg
+output_folder="output/$NSIDE/$sim/$NUM"
+mkdir -p $output_folder
+config_file="$output_folder/common.cfg"
+cp $template_config_file $config_file
+echo "MAPSIMS RUN: $NSIDE $sim $NUM"
+sim+="_{nside}.cfg"
+time mapsims_run $config_file $sim

--- a/201903_highres_foregrounds/synchrotron_4096.cfg
+++ b/201903_highres_foregrounds/synchrotron_4096.cfg
@@ -1,0 +1,3 @@
+content = synchrotron
+[pysm_components]
+pysm_components_string = SO_s0s

--- a/201903_highres_foregrounds/synchrotron_512.cfg
+++ b/201903_highres_foregrounds/synchrotron_512.cfg
@@ -1,0 +1,3 @@
+content = synchrotron
+[pysm_components]
+pysm_components_string = SO_s0


### PR DESCRIPTION
Simulations at 4096 and 512 for all channels using high resolution foreground models: https://so-pysm-models.readthedocs.io/en/0.2.dev/highres_templates.html#details-about-individual-models