### PR TITLE
S0014 20230920

### DIFF
--- a/LOGBOOK.md
+++ b/LOGBOOK.md
@@ -2,6 +2,10 @@
 
 Date based updates from the map based simulation team
 
+## 20 Sep 2023 - Released realistic SAT map-based noise simulations
+
+Based the SAT time-domain ``mbs-noise-sims-sat`` simulations, using the tiled noise model of [`mnms`](https://github.com/simonsobs/mnms).
+
 ## 9 May 2023 - Released realistic LAT map-based noise simulations
 
 Based the LAT time-domain `scan-s0003` simulations, using the directional wavelet noise model of [`mnms`](https://github.com/simonsobs/mnms).

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@ Map based simulations for the Simons Observatory
 
 Map based simulations for Simons Observatory, documentation about releases, maintained by the Map-Based Simulation Pipeline Working Group (MBS)
 
-Slack channel: `#pwg-mbs`
+Slack channel: `#dm-simulations`
 
 ## Available simulations
 
+* [`mbs-s0014-20230920`](mbs-s0013-20230920/README.md): Map-based noise simulations based on the SAT `mbs-noise-sims-sat` time-domain simulations
 * [`mbs-s0013-20230501`](mbs-s0013-20230501/README.md): Map-based noise simulations based on the LAT `scan-s0003` time-domain simulations
 * [`mbs-s0012-20230321`](mbs-s0012-20230321/README.md): Galactic, extragalactic, CMB with realistic bandpasses.
 * [`mbs-s0011-20200618`](202006_noise/README.md): Reran of realistic noise version 3.1.1 with MSS1 hitmaps

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Slack channel: `#dm-simulations`
 
 ## Available simulations
 
-* [`mbs-s0014-20230920`](mbs-s0013-20230920/README.md): Map-based noise simulations based on the SAT `mbs-noise-sims-sat` time-domain simulations
+* [`mbs-s0014-20230920`](mbs-s0014-20230920/README.md): Map-based noise simulations based on the SAT `mbs-noise-sims-sat` time-domain simulations
 * [`mbs-s0013-20230501`](mbs-s0013-20230501/README.md): Map-based noise simulations based on the LAT `scan-s0003` time-domain simulations
 * [`mbs-s0012-20230321`](mbs-s0012-20230321/README.md): Galactic, extragalactic, CMB with realistic bandpasses.
 * [`mbs-s0011-20200618`](202006_noise/README.md): Reran of realistic noise version 3.1.1 with MSS1 hitmaps

--- a/mbs-s0014-20230920/README.md
+++ b/mbs-s0014-20230920/README.md
@@ -16,18 +16,31 @@ This release is based on the [mbs-noise-sims-sat](https://github.com/simonsobs/p
 
     /global/cfs/cdirs/sobs/sims/sat-noise-sims/v1
 
-These time-domain simulations include detector and atmospheric noise scaled to match a full year of sensitivity split into two disjoint maps for each frequency band. 
+These **noise-only** time-domain simulations include detector and atmospheric noise scaled to match a full year of sensitivity split into two disjoint maps for each frequency band. In more detail:
+* One year, three calendar days per month
+* Full SAT focalplanes
+* HWP demodulation
+* Variable mapmaking resolution
+    * NSide=128 for 30 and 40GHz (LF)
+    * NSide=512 for 90 and 150GHz (MF)
+    * NSide=1024 for 230 and 290Ghz (HF)
+* Up to hour-long uninterrupted observations
+* Two time-domain filters:
+    * 20th order ground polynomial filter
+    * 1st order subscan polynomial filter
+* Noise and atmosphere scaled to match full year of sensitivity split into two disjoint maps
 
 Using [`mnms`](https://github.com/simonsobs/mnms), we generate 300 realizations of the noise using map-based methods. Specifically, we use the tiled model, governed by the configured [parameters](parameters/so_sat_v1_f1.yaml).
 
 Notes:
+* The following releases were used: [`mnms v0.0.4`](https://github.com/simonsobs/mnms/tree/v0.0.4) and [`sofind v0.0.4`](https://github.com/simonsobs/sofind/tree/v0.0.4)
 * Both time-domain and map-domain simulations are stored in HEALPix format. See [examples](#example-usage) below for further guidance.
 * A mask has been applied to the map-domain simulations. The masks are stored here: `/global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0014_20230920/car/masks/coadd_SAT_{bands}_mask_obs_hp.fits`.
 * See these [slides](https://drive.google.com/file/d/1ZkwpjYQVCkmbRk5RWOp0Qq4CPsynBH31/view?usp=sharing) for validation of the map-based simulations.
 
 ## Available maps
 
-Maps are available in the HEALPix format. Maps are in Equatorial Coordinates, `K_CMB` units, FITS format.
+Maps are available in the HEALPix format. Maps are in Equatorial Coordinates, `K_CMB` units, FITS format. 
 
 The maps are available on `NERSC` at:
 
@@ -39,7 +52,9 @@ and have the following naming convention:
 so_sat_v1_f1_tile_{band}_2way_set{split_num}_noise_sim_map{sim_num:04}.fits
 ```
 
-where `band` is in `[f030, f040, f090, f150, f230, f290]`, `split_num` is in `[0-1]` and `sim_num` is in `[0000-0299]`. Note that the `split_num` is 0-indexed for the map-based sims, while it is 1-indexed for the TOD sims.
+where `band` is in `[f030, f040, f090, f150, f230, f290]`, `split_num` is in `[0-1]` and `sim_num` is in `[0000-0299]`. Note that the `split_num` is 0-indexed for the map-based sims, while it is 1-indexed for the TOD sims. 
+
+The maps take up 215 GB.
 
 Please [open an issue here](https://github.com/simonsobs/map_based_simulations/issues/new) for any data access problems.
 

--- a/mbs-s0014-20230920/README.md
+++ b/mbs-s0014-20230920/README.md
@@ -1,0 +1,98 @@
+# Map-based noise simulations based on the SAT `mbs-noise-sims-sat` time-domain simulations
+
+Tag: `mbs-s0014-20230920`
+
+## Updates
+
+* 2023-09-20: first release.
+
+## Summary
+
+300 realistic realizations of the SAT map noise, estimated from the [mbs-noise-sims-sat](https://github.com/simonsobs/pwg-scripts/tree/master/pwg-tds/mbs-noise-sims-sat) time-domain noise simulations. Simulations cover the full SAT footprint and utilize the tiled noise model.
+
+## Noise model
+
+This release is based on the [mbs-noise-sims-sat](https://github.com/simonsobs/pwg-scripts/tree/master/pwg-tds/mbs-noise-sims-sat) time-domain simulations, available on `NERSC` at:
+
+    /global/cfs/cdirs/sobs/sims/sat-noise-sims/v1
+
+These time-domain simulations include detector and atmospheric noise scaled to match a full year of sensitivity split into two disjoint maps for each frequency band. 
+
+Using [`mnms`](https://github.com/simonsobs/mnms), we generate 300 realizations of the noise using map-based methods. Specifically, we use the tiled model, governed by the configured [parameters](parameters/so_sat_v1_f1.yaml).
+
+Notes:
+* Both time-domain and map-domain simulations are stored in HEALPix format. See [examples](#example-usage) below for further guidance.
+* A mask has been applied to the map-domain simulations. The masks are stored here: `/global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0014_20230920/car/masks/coadd_SAT_{bands}_mask_obs_hp.fits`.
+* See these [slides](https://drive.google.com/file/d/1ZkwpjYQVCkmbRk5RWOp0Qq4CPsynBH31/view?usp=sharing) for validation of the map-based simulations.
+
+## Available maps
+
+Maps are available in the HEALPix format. Maps are in Equatorial Coordinates, `K_CMB` units, FITS format.
+
+The maps are available on `NERSC` at:
+
+    /global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0014_20230920/out/run00
+
+and have the following naming convention:
+
+```python
+so_sat_v1_f1_tile_{band}_2way_set{split_num}_noise_sim_map{sim_num:04}.fits
+```
+
+where `band` is in `[f030, f040, f090, f150, f230, f290]`, `split_num` is in `[0-1]` and `sim_num` is in `[0000-0299]`. Note that the `split_num` is 0-indexed for the map-based sims, while it is 1-indexed for the TOD sims.
+
+Please [open an issue here](https://github.com/simonsobs/map_based_simulations/issues/new) for any data access problems.
+
+## Example usage
+
+```python
+import os
+import numpy as np
+import healpy as hp
+
+opj = os.path.join
+
+# First get some basic info like the path and the filename template.
+fdir = '/global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0014_20230920/out/run00'
+fbase_template = 'so_sat_v1_f1_tile_{band}_2way_set{split_num}_noise_sim_map{sim_num:04}.fits'
+
+# Let's load the sim for e.g. f150, split 0, sim 123.
+band = 'f150'
+split_num = 0
+sim_num = 123               # Has 4 digits (leading 0's), but padding done for us in template.
+
+sim = hp.read_map(
+    opj(fdir, fbase_template.format(
+        band=band,
+        split_num=split_num,
+        sim_num=sim_num)
+        ),
+    field=None  # Load I, Q, and U maps in one go. First axis denotes Stokes I, Q and U.
+    )
+print(sim.shape, sim.dtype)
+```
+This should give:
+```python
+(3, 3145728), float32 
+```
+
+## Drawing additional simulations
+
+The `runs/run00` script serves as an example of how to draw additional simulations. Note that the script was set up for use on the Simons Foundation cluster. For use on `NERSC`, the script has to be updated with the appropriate filepaths.
+
+The covariance matrices from which simulations are drawn are available here: 
+
+    /global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0014_20230920/models
+    
+The masks are stored here:
+
+    /global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0014_20230920/car/masks
+
+
+## Preprocessing the TOD simulations
+
+To derive the models, the TOD sims have been preprocessed. This process consists of calling the `project2car.py`, `compare_spectra.py`, `inpaint.py` and `get_masks.py` scripts in order. This is not necessary to repeat, but scripts are included for completeness.
+
+## Feedback
+
+If anything looks suspicious in the simulations, please do not hesitate to [open an issue here](https://github.com/simonsobs/mnms/issues/new).

--- a/mbs-s0014-20230920/check_sims.py
+++ b/mbs-s0014-20230920/check_sims.py
@@ -1,0 +1,161 @@
+'''
+Compare the power spectra of one of the sim to the data.
+'''
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+
+import os
+import numpy as np
+
+import healpy as hp
+import pymaster as nmt
+from pixell import enmap, sharp, curvedsky, reproject
+from optweight import mat_utils
+
+opj = os.path.join
+
+mapdir = '/mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1'
+cardir = '/mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1/car'
+simdir = '/mnt/home/aduivenvoorden/project/actpol/maps/mnms/sims'
+maskdir = opj(cardir, 'masks')
+ratiodir = opj(cardir, 'ratios')
+imgdir = opj(mapdir, 'img_car')
+specdir = opj(mapdir, 'spec')
+
+os.makedirs(imgdir, exist_ok=True)
+os.makedirs(specdir, exist_ok=True)
+os.makedirs(ratiodir, exist_ok=True)
+
+freqs = ['f030', 'f040', 'f090', 'f150', 'f230', 'f290']
+aposcale = 2.5
+
+sidx = 1
+
+freq_pairs = [('f030', 'f040'), ('f090', 'f150'), ('f230', 'f290')]
+sim_idx = 1
+#simtype = 'fdw'
+simtype = 'tile'
+
+simdict = {'f030' : [f'so_sat_v1_f1_{simtype}_lf_lf_f030_lf_f040_lmax405_2way_set{sidx-1}_noise_sim_map{sim_idx:04d}.fits',
+                     np.s_[0,...]],
+           'f040' : [f'so_sat_v1_f1_{simtype}_lf_lf_f030_lf_f040_lmax405_2way_set{sidx-1}_noise_sim_map{sim_idx:04d}.fits',
+                     np.s_[1,...]],
+           'f090' : [f'so_sat_v1_f1_{simtype}_mf_mf_f090_mf_f150_lmax1620_2way_set{sidx-1}_noise_sim_map{sim_idx:04d}.fits',
+                     np.s_[0,...]],
+           'f150' : [f'so_sat_v1_f1_{simtype}_mf_mf_f090_mf_f150_lmax1620_2way_set{sidx-1}_noise_sim_map{sim_idx:04d}.fits',
+                     np.s_[1,...]],
+           'f230' : [f'so_sat_v1_f1_{simtype}_uhf_uhf_f230_uhf_f290_lmax3240_2way_set{sidx-1}_noise_sim_map{sim_idx:04d}.fits',
+                     np.s_[0,...]],
+           'f290' : [f'so_sat_v1_f1_{simtype}_uhf_uhf_f230_uhf_f290_lmax3240_2way_set{sidx-1}_noise_sim_map{sim_idx:04d}.fits',
+                     np.s_[1,...]]}
+lmax_dict = {'f030' : 405, 'f040' : 405, 'f090' : 1620, 'f150' : 1620, 'f230' : 3240, 'f290' : 3240}
+
+for pair in freq_pairs:
+
+    mask = enmap.read_map(opj(maskdir, f'coadd_SAT_{pair[0]}_{pair[1]}_mask_est.fits'))
+
+    for freq in pair:
+
+        #for sidx in range(1, 3):
+        for _ in [1]:
+            
+            imap = enmap.read_map(opj(cardir,  f'coadd_SAT_{freq}_2way_set0{sidx-1}_map_inpaint.fits'))
+            ivar = enmap.read_map(opj(cardir,  f'coadd_SAT_{freq}_2way_set0{sidx-1}_ivar_inpaint.fits'))
+
+            sim = enmap.read_map(opj(simdir, simdict[freq][0]), sel=simdict[freq][1])[0]
+                                 
+            for weight in ['flat', 'ivar']:
+
+                mask_eff = enmap.zeros((1,) + ivar.shape[-2:], dtype=ivar.dtype, wcs=ivar.wcs)
+
+                if weight == 'ivar':
+                    mask_eff[0] = ivar[0] / ivar[0].max() * mask
+                else:
+                    mask_eff[0] = mask
+
+                mask_eff_dg = enmap.project(mask_eff, sim.shape[-2:], sim.wcs)
+
+                lmax = lmax_dict[freq]                
+                ainfo = sharp.alm_info(lmax)
+                ells = np.arange(lmax + 1)
+                                 
+                alm = curvedsky.map2alm(imap * mask_eff, ainfo=ainfo)
+                nl = ainfo.alm2cl(alm[:,None,:], alm[None,:,:])
+
+                alm_sim = curvedsky.map2alm(sim * mask_eff_dg, ainfo=ainfo)
+                nl_sim = ainfo.alm2cl(alm_sim[:,None,:], alm_sim[None,:,:])
+                
+                fig, axs = plt.subplots(ncols=3, nrows=3, dpi=300, constrained_layout=True)
+
+                for aidxs, ax in np.ndenumerate(axs):
+                    
+                    if aidxs[0] == aidxs[1]:
+                    
+                        axs[aidxs].plot(ells, nl[aidxs[0],aidxs[1]],
+                                        lw=0.5)
+                        axs[aidxs].plot(ells, nl_sim[aidxs[0],aidxs[1]],
+                                        lw=0.5)
+                    else:
+
+                        num = nl[aidxs[0],aidxs[1]]
+                        den = np.sqrt(nl[aidxs[0],aidxs[0]] *  nl[aidxs[1],aidxs[1]])                        
+                        rho = np.zeros_like(num)
+                        np.divide(num, den, where=den != 0, out=rho)
+
+                        
+                        axs[aidxs].plot(ells, rho, lw=0.5)
+
+                        num = nl_sim[aidxs[0],aidxs[1]]
+                        den = np.sqrt(nl_sim[aidxs[0],aidxs[0]] *  nl_sim[aidxs[1],aidxs[1]])                        
+                        rho = np.zeros_like(num)
+                        np.divide(num, den, where=den != 0, out=rho)
+                        
+                        axs[aidxs].plot(ells, rho, lw=0.5)
+                                            
+                    if aidxs[0] == aidxs[1]:
+                        axs[aidxs].set_yscale('log')
+
+                    axs[aidxs].set_xlim(1)
+                    axs[aidxs].set_xscale('log')                    
+                        
+                fig.savefig(opj(imgdir, f'coadd_SAT_{freq}_00{sidx}of002_spectra_sim_compared_{weight}'))
+                
+                for aidxs, ax in np.ndenumerate(axs):
+
+                    if aidxs[0] == aidxs[1]:
+                        axs[aidxs].set_yscale('linear')
+                    # This is a fun bug in matplotlib.
+                    axs[aidxs].set_xscale('linear')
+                    axs[aidxs].set_xscale('log')
+                    axs[aidxs].set_xscale('linear')                    
+                    axs[aidxs].set_xlim(0, 200)
+                fig.savefig(opj(imgdir, f'coadd_SAT_{freq}_00{sidx}of002_spectra_sim_compared_{weight}_linear'))                
+                plt.close(fig)
+
+            # Also plot maps weighted by sqrt(ivar).
+            mask_eff = enmap.zeros((1,) + ivar.shape[-2:], dtype=ivar.dtype, wcs=ivar.wcs)
+            mask_eff[0] = ivar[0] * np.sqrt(ivar[0]) * mask
+
+            lmax = lmax_dict[freq] * 2
+            ainfo = sharp.alm_info(lmax)
+            ells = np.arange(lmax + 1)
+
+            alm = curvedsky.map2alm(imap * mask_eff, ainfo=ainfo)
+            nl = ainfo.alm2cl(alm[:,None,:], alm[None,:,:])
+
+            fig, axs = plt.subplots(ncols=3, nrows=3, dpi=300, constrained_layout=True)
+
+            for aidxs, ax in np.ndenumerate(axs):
+
+                axs[aidxs].plot(ells, nl[aidxs[0],aidxs[1]],
+                                lw=0.5)
+                
+                if aidxs[0] == aidxs[1]:
+                    axs[aidxs].set_yscale('log')
+
+                axs[aidxs].set_xlim(1)
+                axs[aidxs].set_xscale('log')                    
+
+            fig.savefig(opj(imgdir, f'coadd_SAT_{freq}_00{sidx}of002_spectra_sqrt_ivar'))
+            plt.close(fig)

--- a/mbs-s0014-20230920/check_sims_hp.py
+++ b/mbs-s0014-20230920/check_sims_hp.py
@@ -1,0 +1,479 @@
+'''
+Plot output healpix maps and compare spectra to input TOD sims.
+'''
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+
+import os
+import numpy as np
+
+import healpy as hp
+import pymaster as nmt
+from pixell import enmap, sharp, curvedsky, reproject, enplot, mpi as p_mpi
+from optweight import mat_utils
+
+from mpi4py import MPI
+comm = MPI.COMM_WORLD
+
+opj = os.path.join
+
+mapdir = '/mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1'
+cardir = '/mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1/car'
+outdir = opj(mapdir, 'out', 'run00')
+maskdir = opj(cardir, 'masks')
+imgdir = opj(mapdir, 'out/run00/img')
+specdir = opj(outdir, 'spec')
+
+os.makedirs(imgdir, exist_ok=True)
+os.makedirs(specdir, exist_ok=True)
+
+def numpy_to_mpi_type(dtype):
+    '''
+    Convert numpy dtype to MPI data_type.
+
+    Paramters
+    ---------
+    dtype : dtype
+        Numpy dtype
+
+    Returns
+    -------
+    data_type : mpi4py.MPI.Datatype
+        Corresponding MPI data type.
+    '''
+
+    # Will crash if no MPI, but OK, this function should not have been called.
+    from mpi4py import MPI
+    # Could also used mpi.util.dtlib. But was only added in mpi4py 3.1.0.
+    return MPI._typedict[np.dtype(dtype).char]
+
+def bcast_array_meta(arr, comm, root=0):
+    '''
+    Broadcast shape and dtype of array.
+
+    Parameters
+    ----------
+    arr : array, None
+        Array on root.
+    comm : MPI communicator
+    root : int, optional
+        Broadcast info from this rank.
+
+    Returns
+    -------
+    shape : tuple
+    dtype : type
+    '''
+
+    if isinstance(comm, p_mpi.FakeCommunicator) or comm.Get_size() == 1:
+        return arr.shape, arr.dtype
+
+    if comm.Get_rank() == root:
+        shape = arr.shape
+        dtype = arr.dtype
+    else:
+        shape, dtype = None, None
+
+    shape = comm.bcast(shape, root=root)
+    dtype = comm.bcast(dtype, root=root)
+
+    return shape, dtype
+
+def bcast_array(arr, comm, root=0):
+    '''
+    Broadcast array.
+
+    Parameters
+    ----------
+    arr : array
+        Array on root.
+    comm : MPI communicator
+    root : int, optional
+        Broadcast array from this rank.
+
+    Returns
+    -------
+    arr_out : array
+        Broadcasted array on all ranks.
+    '''
+
+    if isinstance(comm, p_mpi.FakeCommunicator) or comm.Get_size() == 1:
+        return arr
+
+    shape, dtype = bcast_array_meta(arr, comm, root=root)
+
+    if comm.Get_rank() != root:
+        arr = np.zeros(shape, dtype=dtype)
+
+    mpi_type = numpy_to_mpi_type(arr.dtype)
+    comm.Bcast([arr, mpi_type], root=root)
+
+    return arr
+
+def reduce_array(arr, comm, op=None, root=0):
+    '''
+    Reduce numpy array to root.
+
+    Parameters
+    ----------
+    arr : array
+    comm : MPI communicator
+    op : mpi4py.MPI.Op object, optional
+        Operation during reduce, defaults to SUM.
+    root : int, optional
+        Reduce array to this rank.
+
+    Returns
+    -------
+    arr_out : array, None
+        Reduced array on root, None on other ranks.
+    '''
+
+    if isinstance(comm, p_mpi.FakeCommunicator) or comm.Get_size() == 1:
+        return arr
+
+    if comm.Get_rank() == root:
+        arr_out = np.zeros_like(arr)
+    else:
+        arr_out = None
+
+    if op is not None:
+        comm.Reduce(arr, arr_out, op=op, root=root)
+    else:
+        comm.Reduce(arr, arr_out, root=root)
+
+    return arr_out
+
+freqs = ['f030', 'f040', 'f090', 'f150', 'f230', 'f290']
+npol = 3
+freq_pairs = [('f030', 'f040'), ('f090', 'f150'), ('f230', 'f290')]
+
+def compute_master(f_a, f_b, wsp):
+    '''
+    Compute MASTER spectrum.
+
+    Parameters
+    ----------
+    f_a : NmtField
+        First field.
+    f_c : NmtField
+        Second field.
+    wsp : NmtWorkspace
+        Workspace containing coupling matrix.
+
+    Returns
+    -------
+    cl_decoupled : array
+        Decoupled C_ells, shape varies based on spin.
+    '''
+
+    cl_coupled = nmt.compute_coupled_cell(f_a, f_b)
+    cl_decoupled = wsp.decouple_cell(cl_coupled)
+
+    return cl_decoupled
+
+for pair in freq_pairs:
+
+    if comm.rank == 0:
+        mask_obs = hp.read_map(opj(maskdir, f'coadd_SAT_{pair[0]}_{pair[1]}_mask_obs_hp.fits'))
+        nside = hp.npix2nside(mask_obs.shape[-1])
+
+        # Reproject mask_est.
+        mask_est = enmap.read_map(opj(maskdir, f'coadd_SAT_{pair[0]}_{pair[1]}_mask_est.fits'))
+        shape = mask_est.shape
+        wcs =  mask_est.wcs
+        mask_est = reproject.map2healpix(mask_est, nside=nside, extensive=False,
+                                        method='spline', order=1, spin=0)
+        meta = [nside, shape, wcs]
+    else:
+        mask_est, mask_obs = None, None
+        meta = None
+
+    mask_obs = bcast_array(mask_obs, comm)
+    mask_est = bcast_array(mask_est, comm)
+    meta = comm.bcast(meta, root=0)
+    nside, shape, wcs = meta
+
+    for sidx in range(1, 3):
+
+        nmt_fields = {}
+        masks = {}
+        vmin_dict = {}
+        vmax_dict = {}
+
+        for freq in pair:
+
+            nmt_fields[freq] = {}
+
+            if comm.rank == 0:
+                imap_data = hp.read_map(
+                    opj(mapdir, f'coadd_SAT_{freq}_00{sidx}of002_map.fits'),
+                    field=None)
+                imap_data[imap_data == hp.UNSEEN] = 0
+
+                ivar_data = hp.read_map(
+                    opj(mapdir, f'coadd_SAT_{freq}_00{sidx}of002_invcov.fits'),
+                    field=0)
+                ivar_data[ivar_data == hp.UNSEEN] = 0
+            else:
+                imap_data, ivar_data = None, None
+            imap_data = bcast_array(imap_data, comm)
+            ivar_data = bcast_array(ivar_data, comm)
+
+            imap_data *= 1e6
+            ivar_data *= 1e-12
+
+            # Plot data maps.
+            if freq in ('f030', 'f040'):
+                font_size = 20
+                downgrade = None
+            elif freq in ('f090', 'f150'):
+                font_size = 60
+                downgrade = 2
+            else:
+                font_size = 80
+                downgrade = 6
+
+            # For visual comparison, reproject map using nearest-neighbor.
+            tmin, tmax = (np.quantile(imap_data[0], 0.01), np.quantile(imap_data[0], 0.99))
+            pmin, pmax = (np.quantile(imap_data[1], 0.01), np.quantile(imap_data[1], 0.99))
+            vmin = [tmin, pmin, pmin]
+            vmax = [tmax, pmax, pmax]
+            vmin_dict[freq] = vmin
+            vmax_dict[freq] = vmax
+
+            if comm.rank == 0:
+                # Note, we apply mask_obs.
+                omap_spline = reproject.healpix2map(
+                    imap_data * mask_obs, shape=shape, wcs=wcs, extensive=False,
+                    method='spline', order=0)
+                for pidx in range(npol):
+                    plot = enplot.plot(omap_spline[pidx], colorbar=True, ticks=30,
+                                       min=vmin[pidx], max=vmax[pidx],
+                                       font_size=font_size)
+                    enplot.write(opj(imgdir, f'coadd_SAT_{freq}_00{sidx}of002_map_spline_{pidx}'), plot)
+
+            # Init namaster fields.
+            bins = nmt.NmtBin.from_nside_linear(nside, 10)
+            ells = bins.get_effective_ells()
+            lmax = int(ells[-1] + 100)
+
+            for weight in ['flat', 'ivar']:
+
+                nmt_fields[freq][weight] = {}
+
+                mask_eff = np.zeros((1, mask_est.shape[-1]), dtype=ivar_data.dtype)
+                if weight == 'ivar':
+                    mask_eff[0] = ivar_data / ivar_data.max() * mask_est
+                else:
+                    mask_eff[0] = mask_est
+
+                masks[weight] = mask_eff
+
+                f0 = nmt.NmtField(mask_eff[0], [imap_data[0]], lmax_sht=lmax)
+                f2 = nmt.NmtField(mask_eff[0] , [imap_data[1], imap_data[2]], lmax_sht=lmax)
+
+                nmt_fields[freq][weight]['f0'] = f0
+                nmt_fields[freq][weight]['f2'] = f2
+
+        if comm.rank == 0:
+            np.save(opj(specdir, f'ells_{pair[0]}_{pair[1]}_set{sidx}_data'), ells)
+                
+        workspaces = {}
+        weights = ['flat', 'ivar']
+
+        for weight in weights:
+            for freq1 in pair:
+                for freq2 in pair:
+                    for spin1 in [0, 2]:
+                        for spin2 in [0, 2]:
+
+                            if comm.rank == 0:
+                                print(freq1, freq1, spin1, spin2)
+
+                            wsp = nmt.NmtWorkspace()
+                            f_a = nmt_fields[freq1][weight][f'f{spin1}']
+                            f_b = nmt_fields[freq1][weight][f'f{spin2}']
+
+                            wsp.compute_coupling_matrix(f_a, f_b, bins)
+
+                            workspaces[f'{weight}_{freq1}_{freq2}_{spin1}_{spin2}'] = wsp
+
+        spectra_data = np.zeros((len(weights), 2, 2, 3, 3, ells.size))
+
+        for widx, weight in enumerate(weights):
+            for fidx1, freq1 in enumerate(pair):
+
+                f_a_0 = nmt_fields[freq1][weight]['f0']
+                f_a_2 = nmt_fields[freq1][weight]['f2']
+
+                for fidx2, freq2 in enumerate(pair):
+
+                    if comm.rank == 0:
+                        print(widx, fidx1, fidx2)
+
+                    f_b_0 = nmt_fields[freq2][weight]['f0']
+                    f_b_2 = nmt_fields[freq2][weight]['f2']
+
+                    cl_00 = compute_master(
+                        f_a_0, f_b_0, workspaces[f'{weight}_{freq1}_{freq2}_0_0'])
+                    cl_02 = compute_master(
+                        f_a_0, f_b_2, workspaces[f'{weight}_{freq1}_{freq2}_0_2'])
+                    cl_20 = compute_master(
+                        f_a_2, f_b_0, workspaces[f'{weight}_{freq1}_{freq2}_2_0'])
+                    cl_22 = compute_master(
+                        f_a_2, f_b_2, workspaces[f'{weight}_{freq1}_{freq2}_2_2'])
+
+                    spectra_data[widx,fidx1,fidx2,0,0] =  cl_00[0]
+                    spectra_data[widx,fidx1,fidx2,0,1] =  cl_02[0]
+                    spectra_data[widx,fidx1,fidx2,0,2] =  cl_02[1]
+                    spectra_data[widx,fidx1,fidx2,1,0] =  cl_20[0]
+                    spectra_data[widx,fidx1,fidx2,1,1] =  cl_22[0]
+                    spectra_data[widx,fidx1,fidx2,1,2] =  cl_22[1]
+                    spectra_data[widx,fidx1,fidx2,2,0] =  cl_20[1]
+                    spectra_data[widx,fidx1,fidx2,2,1] =  cl_22[2]
+                    spectra_data[widx,fidx1,fidx2,2,2] =  cl_22[3]
+
+        if comm.rank == 0:
+            np.save(opj(specdir, f'spectra_{pair[0]}_{pair[1]}_set{sidx}_data'), spectra_data)
+
+            for widx, weight in enumerate(weights):
+                for fidx1, freq1 in enumerate(pair):
+                    for fidx2, freq2 in enumerate(pair):
+
+                        fig, axs = plt.subplots(ncols=3, nrows=3, dpi=300, constrained_layout=True)
+
+                        for aidxs, ax in np.ndenumerate(axs):
+
+                            axs[aidxs].plot(ells, spectra_data[widx,fidx1,fidx2,aidxs[0],aidxs[1]],
+                                            lw=0.5)
+
+                            if aidxs[0] == aidxs[1]:
+                                axs[aidxs].set_yscale('linear')
+                            # This is a fun bug in matplotlib.
+                            axs[aidxs].set_xscale('linear')
+                            axs[aidxs].set_xscale('log')
+                            axs[aidxs].set_xscale('linear')
+                            axs[aidxs].set_xlim(0, 200)
+                        fig.savefig(opj(imgdir,
+                                f'coadd_SAT_{freq1}_{freq2}_00{sidx}of002_spectra_{weight}_linear'))
+                        plt.close(fig)
+
+        # Now, compute the same for the sims.
+        nsim = 300
+        spectra_sims = np.zeros((len(weights), nsim, 2, 2, 3, 3, ells.size))
+
+        nmt_fields = {}
+
+        for sim_idx in range(comm.rank, nsim, comm.size):
+
+            for freq in pair:
+                print(f'{freq}, sim {sim_idx}')
+                nmt_fields[freq] = {}
+
+                imap_sim = hp.read_map(
+                    opj(outdir,
+                        f'so_sat_v1_f1_tile_{freq}_2way_set{sidx-1}_noise_sim_map{sim_idx:04d}.fits'),
+                    field=None)
+
+                imap_sim *= 1e6
+
+                # Plot sim.
+                if freq in ('f030', 'f040'):
+                    font_size = 20
+                    downgrade = None
+                elif freq in ('f090', 'f150'):
+                    font_size = 60
+                    downgrade = 2
+                else:
+                    font_size = 80
+                    downgrade = 6
+
+                if sim_idx == 0:
+                    # For visual comparison, reproject map using nearest-neighbor.
+                    vmin = vmin_dict[freq]
+                    vmax = vmax_dict[freq]
+
+                    omap_spline = reproject.healpix2map(imap_sim, shape=shape, wcs=wcs, extensive=False,
+                                                        method='spline', order=0)
+                    for pidx in range(npol):
+
+                        plot = enplot.plot(omap_spline[pidx], colorbar=True, ticks=30,
+                                           min=vmin[pidx], max=vmax[pidx],
+                                           font_size=font_size)
+                        enplot.write(
+                            opj(imgdir,
+                        f'so_sat_v1_f1_tile_{freq}_2way_set{sidx-1}_noise_sim_map{sim_idx:04d}_{pidx}'),
+                            plot)
+
+                for weight in ['flat', 'ivar']:
+
+                    nmt_fields[freq][weight] = {}
+
+                    f0 = nmt.NmtField(masks[weight][0], [imap_sim[0]], lmax_sht=lmax)
+                    f2 = nmt.NmtField(masks[weight][0] , [imap_sim[1], imap_sim[2]], lmax_sht=lmax)
+
+                    nmt_fields[freq][weight]['f0'] = f0
+                    nmt_fields[freq][weight]['f2'] = f2
+
+            for widx, weight in enumerate(weights):
+                for fidx1, freq1 in enumerate(pair):
+
+                    f_a_0 = nmt_fields[freq1][weight]['f0']
+                    f_a_2 = nmt_fields[freq1][weight]['f2']
+
+                    for fidx2, freq2 in enumerate(pair):
+
+                        f_b_0 = nmt_fields[freq2][weight]['f0']
+                        f_b_2 = nmt_fields[freq2][weight]['f2']
+
+                        cl_00 = compute_master(
+                            f_a_0, f_b_0, workspaces[f'{weight}_{freq1}_{freq2}_0_0'])
+                        cl_02 = compute_master(
+                            f_a_0, f_b_2, workspaces[f'{weight}_{freq1}_{freq2}_0_2'])
+                        cl_20 = compute_master(
+                            f_a_2, f_b_0, workspaces[f'{weight}_{freq1}_{freq2}_2_0'])
+                        cl_22 = compute_master(
+                            f_a_2, f_b_2, workspaces[f'{weight}_{freq1}_{freq2}_2_2'])
+
+                        spectra_sims[widx,sim_idx,fidx1,fidx2,0,0] =  cl_00[0]
+                        spectra_sims[widx,sim_idx,fidx1,fidx2,0,1] =  cl_02[0]
+                        spectra_sims[widx,sim_idx,fidx1,fidx2,0,2] =  cl_02[1]
+                        spectra_sims[widx,sim_idx,fidx1,fidx2,1,0] =  cl_20[0]
+                        spectra_sims[widx,sim_idx,fidx1,fidx2,1,1] =  cl_22[0]
+                        spectra_sims[widx,sim_idx,fidx1,fidx2,1,2] =  cl_22[1]
+                        spectra_sims[widx,sim_idx,fidx1,fidx2,2,0] =  cl_20[1]
+                        spectra_sims[widx,sim_idx,fidx1,fidx2,2,1] =  cl_22[2]
+                        spectra_sims[widx,sim_idx,fidx1,fidx2,2,2] =  cl_22[3]
+
+        spectra_sims = reduce_array(spectra_sims, comm, op=None, root=0)
+        
+        if comm.rank == 0:
+            np.save(opj(specdir, f'spectra_{pair[0]}_{pair[1]}_set{sidx}_sims'), spectra_sims)
+
+            for widx, weight in enumerate(weights):
+                for fidx1, freq1 in enumerate(pair):
+                    for fidx2, freq2 in enumerate(pair):
+
+                        fig, axs = plt.subplots(ncols=3, nrows=3, dpi=300, constrained_layout=True)
+
+                        for aidxs, ax in np.ndenumerate(axs):
+
+                            for sim_idx in range(nsim):
+                                axs[aidxs].plot(
+                                    ells, spectra_sims[widx,sim_idx,fidx1,fidx2,aidxs[0],aidxs[1]],
+                                    lw=0.5, color='black', alpha=0.3)
+                            axs[aidxs].plot(ells, spectra_data[widx,fidx1,fidx2,aidxs[0],aidxs[1]],
+                                            lw=0.5)
+
+                            if aidxs[0] == aidxs[1]:
+                                axs[aidxs].set_yscale('linear')
+                            # This is a fun bug in matplotlib.
+                            axs[aidxs].set_xscale('linear')
+                            axs[aidxs].set_xscale('log')
+                            axs[aidxs].set_xscale('linear')
+                            axs[aidxs].set_xlim(0, 200)
+                        fig.savefig(opj(imgdir,
+                                f'coadd_SAT_{freq1}_{freq2}_00{sidx}of002_spectra_{weight}_sim_linear'))
+                        plt.close(fig)

--- a/mbs-s0014-20230920/compare_spectra.py
+++ b/mbs-s0014-20230920/compare_spectra.py
@@ -1,0 +1,138 @@
+'''
+Check that noise spectra of reprojected maps from reproject.py agree with spectra from
+the input healpix maps. This also computes a set of ratios between white noise from ivar
+anad the actual noise power spectra which is used as an input to inpaint.py
+'''
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+
+import os
+import numpy as np
+
+import healpy as hp
+import pymaster as nmt
+from pixell import enmap, sharp, curvedsky, reproject
+from optweight import mat_utils
+
+opj = os.path.join
+
+mapdir = '/mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1'
+cardir = '/mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1/car'
+ratiodir = opj(cardir, 'ratios')
+imgdir = opj(mapdir, 'img_car')
+specdir = opj(mapdir, 'spec')
+
+os.makedirs(imgdir, exist_ok=True)
+os.makedirs(specdir, exist_ok=True)
+os.makedirs(ratiodir, exist_ok=True)
+
+freqs = ['f030', 'f040', 'f090', 'f150', 'f230', 'f290']
+aposcale = 2.5
+
+ratios = np.ones((len(freqs), 2, 3)) # nfreq, nsplit, npol.
+
+for fidx, freq in enumerate(freqs):
+
+    for sidx in range(1, 3):
+
+        imap = hp.read_map(
+            opj(mapdir, f'coadd_SAT_{freq}_00{sidx}of002_map.fits'),
+            field=None)
+        imap[imap == hp.UNSEEN] = 0
+        imap *= 1e6
+        nside = hp.npix2nside(imap.shape[-1])
+        lmax = int(2.5 * nside)
+        ells = np.arange(lmax + 1)
+        ainfo = sharp.alm_info(lmax)
+        
+        icov = hp.read_map(
+            opj(mapdir, f'coadd_SAT_{freq}_00{sidx}of002_invcov.fits'),
+            field=None)
+        icov[icov == hp.UNSEEN] = 0
+        icov *= 1e-12
+
+        imap_car = enmap.read_map(opj(cardir,  f'coadd_SAT_{freq}_2way_set0{sidx-1}_map.fits'))
+        ivar_car = enmap.read_map(opj(cardir,  f'coadd_SAT_{freq}_2way_set0{sidx-1}_ivar.fits'))        
+
+        # Draw noise realization.
+        sqrt_var = mat_utils.matpow(ivar_car.reshape(1, np.prod(ivar_car.shape[-2:])),
+                                    -0.5, return_diag=True)
+        noise_car = np.random.randn(*ivar_car.shape) * sqrt_var.reshape(ivar_car.shape)
+        
+        ivar = np.zeros((3, icov.shape[-1]), dtype=icov.dtype)
+        ivar[0] = icov[0]
+        ivar[1] = icov[3]
+        ivar[2] = icov[5]
+
+        mask = (ivar.astype(bool)).astype(ivar.dtype)
+
+        # Shrink mask        
+        mask[0] = nmt.mask_apodization(mask[0], 5, apotype="C1")
+        mask[1] = nmt.mask_apodization(mask[1], 5, apotype="C1")
+        mask[2] = nmt.mask_apodization(mask[2], 5, apotype="C1")
+        mask[mask < 0.7] = 0
+        mask[mask >= 0.7] = 1
+        # Apodize again.
+        mask[0] = nmt.mask_apodization(mask[0], aposcale, apotype="C1")
+        mask[1] = nmt.mask_apodization(mask[1], aposcale, apotype="C1")
+        mask[2] = nmt.mask_apodization(mask[2], aposcale, apotype="C1")
+        
+        for weight in ['flat', 'ivar']:
+
+            mask_eff = np.zeros((3, ivar.shape[-1]), dtype=ivar.dtype)
+            if weight == 'ivar':
+                mask_eff[0] = ivar[0] / ivar[0].max() * mask[0]
+                mask_eff[1] = ivar[1] / ivar[1].max() * mask[1]
+                mask_eff[1] = ivar[2] / ivar[2].max() * mask[2]
+            else:
+                mask_eff[0] = mask[0]
+                mask_eff[1] = mask[1]
+                mask_eff[1] = mask[2]
+
+            # Extensive is False here because we only use ivar as a pixel mask.
+            extensive = False
+            mask_eff_car = reproject.healpix2map(mask_eff, shape=imap_car.shape, wcs=imap_car.wcs,
+                                                 extensive=extensive, method='spline', order=1, spin=0)
+
+            alm = hp.map2alm(imap * mask_eff, lmax)
+            nl = ainfo.alm2cl(alm[:,None,:], alm[None,:,:])
+
+            alm_car = curvedsky.map2alm(imap_car * mask_eff_car, ainfo=ainfo)
+            nl_car = ainfo.alm2cl(alm_car[:,None,:], alm_car[None,:,:])
+
+            alm_noise = curvedsky.map2alm(noise_car * mask_eff_car[0], ainfo=ainfo)
+            nl_noise = ainfo.alm2cl(alm_noise[:,None,:], alm_noise[None,:,:])
+
+            # Determine ratio of the noise power in the maps over draw from ivar.
+            ell_low = int(0.9 * lmax)
+            ell_high = int(0.95 * lmax)
+
+            if weight == 'ivar':
+                ratios[fidx,sidx-1,0] = np.mean(nl_car[0,0,ell_low:ell_high]) / \
+                    np.mean(nl_noise[0,0,ell_low:ell_high])
+                ratios[fidx,sidx-1,1] = np.mean(nl_car[1,1,ell_low:ell_high]) / \
+                    np.mean(nl_noise[0,0,ell_low:ell_high])
+                ratios[fidx,sidx-1,2] = np.mean(nl_car[2,2,ell_low:ell_high]) / \
+                    np.mean(nl_noise[0,0,ell_low:ell_high])
+            
+            fig, axs = plt.subplots(ncols=3, nrows=3, dpi=300, constrained_layout=True)
+            
+            for aidxs, ax in np.ndenumerate(axs):                
+                axs[aidxs].plot(ells, nl[aidxs[0],aidxs[1]],
+                                lw=0.5)
+                axs[aidxs].plot(ells, nl_car[aidxs[0],aidxs[1]],
+                                lw=0.5)
+                if aidxs[0] == aidxs[1]:
+                    fact = 2 if aidxs[0] > 0 else 1
+                    axs[aidxs].plot(ells, nl_noise[0,0] * fact,
+                                    lw=0.5)
+                    
+                if aidxs[0] == aidxs[1]:
+                    axs[aidxs].set_yscale('log')
+                
+            fig.savefig(opj(imgdir, f'coadd_SAT_{freq}_00{sidx}of002_spectra_compared_{weight}'))            
+            plt.close(fig)
+
+np.save(opj(ratiodir, 'ratios.npy'), ratios)
+print(ratios)

--- a/mbs-s0014-20230920/get_masks.py
+++ b/mbs-s0014-20230920/get_masks.py
@@ -1,0 +1,37 @@
+'''
+Construct an apodized mask used for power spectrum estimation.
+'''
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+
+import os
+import numpy as np
+
+from pixell import enmap, enplot
+
+opj = os.path.join
+
+mapdir = '/mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1'
+cardir = opj(mapdir, 'car')
+maskdir = opj(cardir, 'masks')
+imgdir = opj(mapdir, 'img_car')
+
+os.makedirs(imgdir, exist_ok=True)
+os.makedirs(maskdir, exist_ok=True)
+
+freq_pairs = [('f030', 'f040'), ('f090', 'f150'), ('f230', 'f290')]
+
+for pair in freq_pairs:
+
+    mask_obs = enmap.read_map(opj(maskdir, f'coadd_SAT_{pair[0]}_{pair[1]}_mask_obs.fits'))
+    mask_obs = mask_obs.astype(bool)
+    
+    mask_est = enmap.shrink_mask(mask_obs, np.radians(5))
+    mask_est = mask_est.astype(np.float32)
+    mask_est = enmap.apod_mask(mask_est, width=np.radians(5), edge=False)
+
+    plot = enplot.plot(mask_est, ticks=30, colorbar=True)
+    enplot.write(opj(imgdir, f'coadd_SAT_{pair[0]}_{pair[1]}_mask_est'), plot)
+                       
+    enmap.write_map(opj(maskdir, f'coadd_SAT_{pair[0]}_{pair[1]}_mask_est.fits'), mask_est)

--- a/mbs-s0014-20230920/inpaint.py
+++ b/mbs-s0014-20230920/inpaint.py
@@ -1,0 +1,143 @@
+'''
+Inpaint the corners of 2D Fourier space. This is unfortunately needed for the tiled 
+and directional wav. models in mnms at the moment.
+'''
+
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+
+import os
+import numpy as np
+
+import healpy as hp
+from pixell import enmap, sharp, curvedsky, reproject, enplot
+from optweight import mat_utils, alm_c_utils
+
+opj = os.path.join
+
+mapdir = '/mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1'
+cardir = '/mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1/car'
+maskdir = opj(cardir, 'masks')
+ratiodir = opj(cardir, 'ratios')
+imgdir = opj(mapdir, 'img_car')
+specdir = opj(mapdir, 'spec')
+
+os.makedirs(imgdir, exist_ok=True)
+os.makedirs(specdir, exist_ok=True)
+os.makedirs(ratiodir, exist_ok=True)
+
+freqs = ['f030', 'f040', 'f090', 'f150', 'f230', 'f290']
+nsides = {'f030' : 128, 'f040' : 128, 'f090' : 512, 'f150' : 512, 'f230' : 1024, 'f290' : 1024}
+
+ratios = np.load(opj(ratiodir, 'ratios.npy'))
+
+freq_pairs = [('f030', 'f040'), ('f090', 'f150'), ('f230', 'f290')]
+
+
+for paidx, pair in enumerate(freq_pairs):
+
+    mask_obs = enmap.read_map(opj(maskdir, f'coadd_SAT_{pair[0]}_{pair[1]}_mask_obs.fits'))
+    
+    for fridx, freq in enumerate(pair):
+
+        fidx = paidx * 2 + fridx
+        
+        for sidx in range(1, 3):
+
+            imap = enmap.read_map(opj(cardir,  f'coadd_SAT_{freq}_2way_set0{sidx-1}_map.fits'))
+            ivar = enmap.read_map(opj(cardir,  f'coadd_SAT_{freq}_2way_set0{sidx-1}_ivar.fits'))        
+
+            imap = imap.astype(np.float64)
+            ivar = ivar.astype(np.float64)
+
+            imap *= mask_obs
+            ivar *= mask_obs
+            
+            # Upgrade to I, Q, U.
+            ivar = enmap.ones((3,) + ivar.shape[-2:], wcs=ivar.wcs) * ivar
+            ivar[0] /= ratios[fidx,sidx-1,0]
+            # Factor 2 is to compenstate for factor to in ratio.
+            ivar[1:3] /= np.mean(ratios[fidx,sidx-1,1:3]) * 2
+
+            # Draw noise.
+            sqrt_var = mat_utils.matpow(ivar.reshape((3, np.prod(ivar.shape[-2:]))),
+                                        -0.5, return_diag=True)
+            noise = np.random.randn(*ivar.shape) * sqrt_var.reshape(ivar.shape)
+
+            npol = noise.shape[0]
+            font_size = 40 if freq in ('f030', 'f040') else 120
+
+            # Create low-pass filter.
+            lmax_low = int(2.5 * nsides[freq])
+            lmax_large = int(np.round(180/np.abs(imap.wcs.wcs.cdelt[1])))
+            ainfo = sharp.alm_info(lmax_large)            
+            lwidth = max(50, int(lmax_low * 0.05))
+            lowpass_filt = np.ones(lmax_large + 1)
+            lowpass_filt[lmax_low-lwidth:lmax_low+1] *= hp.gauss_beam(2 * np.pi / lwidth, lmax=lwidth)
+            lowpass_filt[lmax_low:] = 0
+                            
+            # Now only add noise beyond bandlimit to imap.
+            # This trick uses that f**2 + (1 - (1 - sqrt(1 - f**2)))**2 = 1.
+            # This is how orphics implements this.
+            lowpass = noise.copy()
+            alm = curvedsky.map2alm(noise, ainfo=ainfo, spin=[0, 2])            
+            alm_c_utils.lmul(alm, 1 - np.sqrt(1 - lowpass_filt ** 2), ainfo, inplace=True)
+            curvedsky.alm2map(alm, lowpass, ainfo=ainfo, spin=[0, 2])
+            noise -= lowpass
+
+            fig, ax = plt.subplots(dpi=300)
+            ax.plot(lowpass_filt)
+            fig.savefig(opj(imgdir, f'coadd_SAT_{freq}_00{sidx}of002_filters'))
+            plt.close()
+            
+            alm = curvedsky.map2alm(imap, ainfo=ainfo, spin=[0, 2])
+            alm_c_utils.lmul(alm, lowpass_filt, ainfo, inplace=True)
+            imap_lowpass = curvedsky.alm2map(alm, imap, ainfo=ainfo, spin=[0, 2])
+                
+            imap = imap_lowpass + noise
+
+            # Get mask.
+            mask = (ivar[0].astype(bool)).astype(ivar.dtype)
+            mask = enmap.apod_mask(mask, width=np.radians(5), edge=False)
+            mask[mask < 0.7] = 0
+            mask[mask >= 0.7] = 1
+            # Apodize again.
+            mask = enmap.apod_mask(mask, width=np.radians(5), edge=False)        
+            mask_eff = ivar[0] / ivar[0].max() * mask
+
+            ells = np.arange(lmax_large + 1)
+            alm = curvedsky.map2alm(imap * mask_eff, ainfo=ainfo)
+            nl = ainfo.alm2cl(alm[:,None,:], alm[None,:,:])
+
+            alm_lowpass = curvedsky.map2alm(imap_lowpass * mask_eff, ainfo=ainfo)
+            nl_lowpass = ainfo.alm2cl(alm_lowpass[:,None,:], alm_lowpass[None,:,:])
+            
+            alm_noise = curvedsky.map2alm(noise * mask_eff, ainfo=ainfo)
+            nl_noise = ainfo.alm2cl(alm_noise[:,None,:], alm_noise[None,:,:])
+
+            # Make a plot as a sanity check.
+            fig, axs = plt.subplots(ncols=3, nrows=3, dpi=300, constrained_layout=True)
+            for aidxs, ax in np.ndenumerate(axs):                
+                axs[aidxs].plot(ells, nl[aidxs[0],aidxs[1]],
+                                lw=0.5)
+                axs[aidxs].plot(ells, nl_noise[aidxs[0],aidxs[1]],
+                                lw=0.5)
+                axs[aidxs].plot(ells, nl_lowpass[aidxs[0],aidxs[1]],
+                                lw=0.5)
+                
+                if aidxs[0] == aidxs[1]:
+                    axs[aidxs].set_yscale('log')
+                    
+            fig.savefig(opj(imgdir, f'coadd_SAT_{freq}_00{sidx}of002_spectra_inpaint'))            
+            plt.close(fig)
+
+            mapname2write = f'coadd_SAT_{freq}_2way_set{sidx-1:02d}_map_inpaint'
+            enmap.write_fits(opj(cardir, f'{mapname2write}.fits'), imap.astype(np.float32))
+
+            # Add symlink for ivar maps.
+            os.remove(opj(cardir,  f'coadd_SAT_{freq}_2way_set0{sidx-1}_ivar_inpaint.fits'))
+            os.symlink(opj(cardir,  f'coadd_SAT_{freq}_2way_set0{sidx-1}_ivar.fits'),
+                       opj(cardir,  f'coadd_SAT_{freq}_2way_set0{sidx-1}_ivar_inpaint.fits'))
+
+

--- a/mbs-s0014-20230920/parameters/so_sat_v1_f1.yaml
+++ b/mbs-s0014-20230920/parameters/so_sat_v1_f1.yaml
@@ -1,0 +1,373 @@
+system_paths:
+  perlmutter: /global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0014_20230920
+  rusty: /mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1/car/mnms
+
+allowed_qids_configs:
+- so_basic_qids.yaml
+
+allowed_qids: 'all'
+
+allowed_qids_extra_kwargs:
+  lfa:
+    num_splits: 2
+
+  lfb:
+    num_splits: 2
+
+  mfa:
+    num_splits: 2
+
+  mfb:
+    num_splits: 2
+
+  uhfa:
+    num_splits: 2
+
+  uhfb:
+    num_splits: 2
+
+fdw_lf:
+  noise_model_class: FDW
+  data_model_name: so_sat_v1
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: default
+  possible_maps_subproduct_kwargs: null
+  calibrated: false
+  catalogs_subproduct: null
+  catalog_name: null
+  differenced: false
+  dtype: f4
+  enforce_equal_qid_kwargs:
+  - array
+  - num_splits
+  filter_kwargs:
+    lim: 0.000001
+    lim0: null    
+    post_filt_rel_downgrade: 2
+  iso_filt_method: harmonic
+  ivar_filt_method: basic
+  ivar_fwhms: null
+  ivar_lmaxs: null
+  kfilt_lbounds: null
+  masks_subproduct: so_sat_v1_f1_masks
+  mask_est_name: coadd_SAT_f030_f040_mask_est.fits
+  mask_est_edgecut: 0
+  mask_est_apodization: 0
+  mask_obs_name: coadd_SAT_f030_f040_mask_obs.fits
+  mask_obs_edgecut: 0
+  model_lim: 0.000001
+  model_lim0: null  
+  qid_names_template: '{array}_{freq}'
+  srcfree: false
+  fwhm_fact_pt1:
+  - 1350
+  - 10.0
+  fwhm_fact_pt2:
+  - 5400
+  - 16.0
+  kern_cut: 0.0001
+  lamb: 1.7
+  n: 12
+  nback:
+  - 12
+  nforw:
+  - 0
+  - 6
+  - 6
+  - 12
+  - 12 
+  - 12
+  - 12
+  p: 2
+  pback:
+  - 2
+  pforw:
+  - 0
+  - 2
+  - 2
+  - 2
+  - 2
+  - 2
+  - 2
+  w_lmax: 405
+  w_lmax_j: 304
+  w_lmin: 10
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'
+
+fdw_mf:
+  noise_model_class: FDW
+  data_model_name: so_sat_v1
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: default
+  possible_maps_subproduct_kwargs: null
+  calibrated: false
+  catalogs_subproduct: null
+  catalog_name: null
+  differenced: false
+  dtype: f4
+  enforce_equal_qid_kwargs:
+  - array
+  - num_splits
+  filter_kwargs:
+    post_filt_rel_downgrade: 2
+    lim: 0.000000001
+    lim0: null    
+  iso_filt_method: harmonic
+  ivar_filt_method: basic
+  ivar_fwhms: null
+  ivar_lmaxs: null
+  kfilt_lbounds: null
+  masks_subproduct: so_sat_v1_f1_masks
+  mask_est_name: coadd_SAT_f090_f150_mask_est.fits
+  mask_est_edgecut: 0
+  mask_est_apodization: 0
+  mask_obs_name: coadd_SAT_f090_f150_mask_obs.fits
+  mask_obs_edgecut: 0
+  model_lim: 0.000001
+  model_lim0: null  
+  qid_names_template: '{array}_{freq}'
+  srcfree: false
+  fwhm_fact_pt1:
+  - 1350
+  - 10.0
+  fwhm_fact_pt2:
+  - 5400
+  - 16.0
+  kern_cut: 0.0001
+  lamb: 1.5
+  n: 10
+  nback:
+  - 0
+  nforw:
+  - 0
+  - 4
+  - 6
+  - 6
+  - 6
+  - 8 
+  - 10
+  - 10
+  - 10
+  - 10
+  - 10
+  p: 2
+  pback:
+  - 0
+  pforw:
+  - 0
+  - 2
+  - 2
+  - 2
+  - 2
+  - 2
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  w_lmax: 2620
+  w_lmax_j: 1600 
+  w_lmin: 15
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'
+
+fdw_uhf:
+  noise_model_class: FDW
+  data_model_name: so_sat_v1
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: default
+  possible_maps_subproduct_kwargs: null
+  calibrated: false
+  catalogs_subproduct: null
+  catalog_name: null
+  differenced: false
+  dtype: f4
+  enforce_equal_qid_kwargs:
+  - array
+  - num_splits
+  filter_kwargs:
+    post_filt_rel_downgrade: 2
+    lim: 0.000000001
+    lim0: null        
+  iso_filt_method: harmonic
+  ivar_filt_method: basic
+  ivar_fwhms: null
+  ivar_lmaxs: null
+  kfilt_lbounds: null
+  masks_subproduct: so_sat_v1_f1_masks
+  mask_est_name: coadd_SAT_f230_f290_mask_est.fits
+  mask_est_edgecut: 0
+  mask_est_apodization: 0
+  mask_obs_name: coadd_SAT_f230_f290_mask_obs.fits
+  mask_obs_edgecut: 0
+  model_lim: 0.000001
+  model_lim0: null  
+  qid_names_template: '{array}_{freq}'
+  srcfree: false
+  fwhm_fact_pt1:
+  - 1350
+  - 10.0
+  fwhm_fact_pt2:
+  - 5400
+  - 16.0
+  kern_cut: 0.0001
+  lamb: 1.7
+  n: 12
+  nback:
+  - 6
+  nforw:
+  - 0
+  - 6
+  - 6
+  - 6
+  - 6
+  - 12
+  - 12
+  - 12
+  - 12
+  - 12
+  - 12
+  p: 2
+  pback:
+  - 2
+  pforw:
+  - 0
+  - 6
+  - 4
+  - 2
+  - 2
+  - 2
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  w_lmax: 3240
+  w_lmax_j: 2240
+  w_lmin: 10
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'
+
+tile_lf:
+  noise_model_class: Tiled
+  data_model_name: so_sat_v1
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: default
+  possible_maps_subproduct_kwargs: null
+  calibrated: false
+  catalogs_subproduct: null
+  catalog_name: null
+  differenced: false
+  dtype: f4
+  enforce_equal_qid_kwargs:
+  - array
+  - num_splits
+  filter_kwargs:
+    post_filt_rel_downgrade: 2
+    lim: 0.000000001
+    lim0: null    
+  iso_filt_method: harmonic
+  ivar_filt_method: basic
+  ivar_fwhms: null
+  ivar_lmaxs: null
+  kfilt_lbounds: null
+  masks_subproduct: so_sat_v1_f1_masks
+  mask_est_name: coadd_SAT_f030_f040_mask_est.fits
+  mask_est_edgecut: 0
+  mask_est_apodization: 0
+  mask_obs_name: coadd_SAT_f030_f040_mask_obs.fits
+  mask_obs_edgecut: 0
+  model_lim: 0.000001
+  model_lim0: null  
+  qid_names_template: '{array}_{freq}'
+  srcfree: false
+  delta_ell_smooth: 70
+  height_deg: 12.0
+  width_deg: 12.0  
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'
+
+tile_mf:
+  noise_model_class: Tiled
+  data_model_name: so_sat_v1
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: default
+  possible_maps_subproduct_kwargs: null
+  calibrated: false
+  catalogs_subproduct: null
+  catalog_name: null
+  differenced: false
+  dtype: f4
+  enforce_equal_qid_kwargs:
+  - array
+  - num_splits
+  filter_kwargs:
+    post_filt_rel_downgrade: 2
+    lim: 0.000000001
+    lim0: null    
+  iso_filt_method: harmonic
+  ivar_filt_method: basic
+  ivar_fwhms: null
+  ivar_lmaxs: null
+  kfilt_lbounds: null
+  masks_subproduct: so_sat_v1_f1_masks
+  mask_est_name: coadd_SAT_f090_f150_mask_est.fits
+  mask_est_edgecut: 0
+  mask_est_apodization: 0
+  mask_obs_name: coadd_SAT_f090_f150_mask_obs.fits
+  mask_obs_edgecut: 0
+  model_lim: 0.000001
+  model_lim0: null  
+  qid_names_template: '{array}_{freq}'
+  srcfree: false
+  delta_ell_smooth: 70
+  height_deg: 12.0
+  width_deg: 12.0  
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'
+
+tile_uhf:
+  noise_model_class: Tiled
+  data_model_name: so_sat_v1
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: default
+  possible_maps_subproduct_kwargs: null
+  calibrated: false
+  catalogs_subproduct: null
+  catalog_name: null
+  differenced: false
+  dtype: f4
+  enforce_equal_qid_kwargs:
+  - array
+  - num_splits
+  filter_kwargs:
+    post_filt_rel_downgrade: 2
+    lim: 0.000000001
+    lim0: null    
+  iso_filt_method: harmonic
+  ivar_filt_method: basic
+  ivar_fwhms: null
+  ivar_lmaxs: null
+  kfilt_lbounds: null
+  masks_subproduct: so_sat_v1_f1_masks
+  mask_est_name: coadd_SAT_f230_f290_mask_est.fits
+  mask_est_edgecut: 0
+  mask_est_apodization: 0
+  mask_obs_name: coadd_SAT_f230_f290_mask_obs.fits
+  mask_obs_edgecut: 0
+  model_lim: 0.000001
+  model_lim0: null  
+  qid_names_template: '{array}_{freq}'
+  srcfree: false
+  delta_ell_smooth: 70
+  height_deg: 12.0
+  width_deg: 12.0  
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'

--- a/mbs-s0014-20230920/plot_sims.py
+++ b/mbs-s0014-20230920/plot_sims.py
@@ -1,0 +1,273 @@
+'''
+Plot additional comparison between data and sims. Maps, 2D power spectra.
+'''
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+
+import os
+import numpy as np
+from scipy import ndimage
+from scipy.interpolate import interp1d
+
+from pixell import enmap, enplot, curvedsky, sharp
+from optweight import alm_c_utils
+
+opj = os.path.join
+
+mapdir = '/mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1'
+cardir = '/mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1/car'
+simdir = '/mnt/home/aduivenvoorden/project/actpol/maps/mnms/sims'
+maskdir = opj(cardir, 'masks')
+ratiodir = opj(cardir, 'ratios')
+imgdir = opj(mapdir, 'img_car/sims_compared')
+specdir = opj(mapdir, 'spec')
+
+os.makedirs(imgdir, exist_ok=True)
+os.makedirs(specdir, exist_ok=True)
+os.makedirs(ratiodir, exist_ok=True)
+
+freqs = ['f030', 'f040', 'f090', 'f150', 'f230', 'f290']
+aposcale = 2.5
+
+#for fidx, freq in enumerate(freqs):
+
+freq_pairs = [('f030', 'f040'), ('f090', 'f150'), ('f230', 'f290')]
+
+sidx = 1
+sim_idx = 1
+#simtype = 'fdw'
+simtype = 'tile'
+
+simdict = {'f030' : [f'so_sat_v1_f1_{simtype}_lf_lf_f030_lf_f040_lmax405_2way_set{sidx-1}_noise_sim_map{sim_idx:04d}.fits',
+                     np.s_[0,...]],
+           'f040' : [f'so_sat_v1_f1_{simtype}_lf_lf_f030_lf_f040_lmax405_2way_set{sidx-1}_noise_sim_map{sim_idx:04d}.fits',
+                     np.s_[1,...]],
+           'f090' : [f'so_sat_v1_f1_{simtype}_mf_mf_f090_mf_f150_lmax1620_2way_set{sidx-1}_noise_sim_map{sim_idx:04d}.fits',
+                     np.s_[0,...]],
+           'f150' : [f'so_sat_v1_f1_{simtype}_mf_mf_f090_mf_f150_lmax1620_2way_set{sidx-1}_noise_sim_map{sim_idx:04d}.fits',
+                     np.s_[1,...]],
+           'f230' : [f'so_sat_v1_f1_{simtype}_uhf_uhf_f230_uhf_f290_lmax3240_2way_set{sidx-1}_noise_sim_map{sim_idx:04d}.fits',
+                     np.s_[0,...]],
+           'f290' : [f'so_sat_v1_f1_{simtype}_uhf_uhf_f230_uhf_f290_lmax3240_2way_set{sidx-1}_noise_sim_map{sim_idx:04d}.fits',
+                     np.s_[1,...]]}
+lmax_dict = {'f030' : 405, 'f040' : 405, 'f090' : 1620, 'f150' : 1620, 'f230' : 3240, 'f290' : 3240}
+
+for pair in freq_pairs:
+
+    mask = enmap.read_map(opj(maskdir, f'coadd_SAT_{pair[0]}_{pair[1]}_mask_obs.fits'))
+
+    for freq in pair:
+
+        font_size = 10 if freq in ('f030', 'f040') else 30
+        lmax = lmax_dict[freq]
+        
+        #for sidx in range(1, 3):
+        for sidx in [1]:
+
+            imap = enmap.read_map(opj(cardir,  f'coadd_SAT_{freq}_2way_set0{sidx-1}_map_inpaint.fits'))
+            ivar = enmap.read_map(opj(cardir,  f'coadd_SAT_{freq}_2way_set0{sidx-1}_ivar_inpaint.fits'))
+
+            plot = enplot.plot(ivar, colorbar=True, ticks=30,
+                               font_size=font_size)
+            enplot.write(opj(imgdir, f'coadd_SAT_{freq}_2way_set0{sidx-1}_ivar_inpaint'), plot)
+
+            mask_eff = mask
+
+            #imap *= mask_eff
+            #imap = imap.downgrade(2)
+
+            sim = enmap.read_map(opj(simdir, simdict[freq][0]), sel=simdict[freq][1])[0]
+            mask_dg = enmap.project(mask_eff, sim.shape[-2:], sim.wcs)
+            ivar_dg = enmap.project(ivar, sim.shape[-2:], sim.wcs)
+            ivar_dg[ivar_dg < 0] = 0
+            sim *= mask_dg
+
+            # Bandlimit TOD sim.
+            alm = curvedsky.map2alm(imap, lmax=lmax_dict[freq])
+            imap = curvedsky.alm2map(alm, sim * 0)
+
+            imap *= mask_dg
+            
+            npol = imap.shape[0]
+            tmin, tmax = (np.quantile(imap[0], 0.03), np.quantile(imap[0], 0.97))
+            pmin, pmax = (np.quantile(imap[1], 0.03), np.quantile(imap[1], 0.97))
+            vmin = [tmin, pmin, pmin]
+            vmax = [tmax, pmax, pmax]
+
+            for pidx in range(npol):
+                plot = enplot.plot(imap[pidx], colorbar=True, ticks=30, min=vmin[pidx], max=vmax[pidx],
+                                   font_size=font_size)
+                enplot.write(opj(imgdir, f'coadd_SAT_{freq}_2way_set0{sidx-1}_map_inpaint_{pidx}'), plot)
+
+                plot = enplot.plot(sim[pidx], colorbar=True, ticks=30, min=vmin[pidx], max=vmax[pidx],
+                                   font_size=font_size)
+                enplot.write(
+                    opj(imgdir, f'coadd_SAT_{freq}_2way_set0{sidx-1}_map_inpaint_sim_{pidx}'), plot)
+
+            # Plot scale-dependent variance.
+            low_ell_filt_low = 20
+            low_ell_filt_high = 100
+            low_ell_filt = np.ones(lmax_dict[freq] + 1)
+            low_ell_filt[:low_ell_filt_low] = 0
+            low_ell_filt[low_ell_filt_high:] = 0
+
+            high_ell_filt_low = 200
+            high_ell_filt_high = 300
+            high_ell_filt = np.ones_like(low_ell_filt)
+            high_ell_filt[:high_ell_filt_low] = 0
+            high_ell_filt[high_ell_filt_high:] = 0
+
+            ainfo = sharp.alm_info(lmax)
+            alm = curvedsky.map2alm(imap * np.sqrt(ivar_dg), lmax=lmax_dict[freq])
+            alm = alm_c_utils.lmul(alm, low_ell_filt, ainfo)
+            omap = curvedsky.alm2map(alm, imap * 0)
+            omap = enmap.smooth_gauss(omap ** 2, np.radians(1))
+            
+            for pidx in range(3):
+                plot = enplot.plot(omap[pidx], colorbar=True, ticks=30,
+                                   font_size=font_size)
+                enplot.write(opj(imgdir, f'coadd_SAT_{freq}_2way_set0{sidx-1}_var_est_low_{pidx}'), plot)
+
+            alm = curvedsky.map2alm(imap * np.sqrt(ivar_dg), lmax=lmax_dict[freq])
+            alm = alm_c_utils.lmul(alm, high_ell_filt, ainfo)
+            omap = curvedsky.alm2map(alm, imap * 0)
+            omap = enmap.smooth_gauss(omap ** 2, np.radians(1))
+
+            for pidx in range(3):
+                plot = enplot.plot(omap[pidx], colorbar=True, ticks=30,
+                                   font_size=font_size)
+                enplot.write(opj(imgdir, f'coadd_SAT_{freq}_2way_set0{sidx-1}_var_est_high_{pidx}'), plot)            
+
+            alm = curvedsky.map2alm(sim * np.sqrt(ivar_dg), lmax=lmax_dict[freq])
+            alm = alm_c_utils.lmul(alm, low_ell_filt, ainfo)
+            omap = curvedsky.alm2map(alm, imap * 0)
+            omap = enmap.smooth_gauss(omap ** 2, np.radians(1))
+            
+            for pidx in range(3):
+                plot = enplot.plot(omap[pidx], colorbar=True, ticks=30,
+                                   font_size=font_size)
+                enplot.write(opj(imgdir, f'coadd_SAT_{freq}_2way_set0{sidx-1}_var_est_low_sim_{pidx}'), plot)
+
+            alm = curvedsky.map2alm(sim * np.sqrt(ivar_dg), lmax=lmax_dict[freq])
+            alm = alm_c_utils.lmul(alm, high_ell_filt, ainfo)
+            omap = curvedsky.alm2map(alm, imap * 0)
+            omap = enmap.smooth_gauss(omap ** 2, np.radians(1))
+
+            for pidx in range(3):
+                plot = enplot.plot(omap[pidx], colorbar=True, ticks=30,
+                                   font_size=font_size)
+                enplot.write(opj(imgdir, f'coadd_SAT_{freq}_2way_set0{sidx-1}_var_est_high_sim_{pidx}'), plot)            
+
+                
+            # Also plot 2D spectra.
+            patches = [np.radians([[-55, 65], [-25, 95]]), np.radians([[5, 135], [-25, 165]])]
+            for paidx, patch in enumerate(patches):
+
+                # Extract patch.
+                submap = enmap.submap(imap, patch)
+                submap = enmap.apod(submap, int(lmax * 0.02))
+
+                submap_sim = enmap.submap(sim, patch)
+                submap_sim = enmap.apod(submap_sim, int(lmax * 0.02))
+
+                if freq in ('f030', 'f040'):
+                    upgrade = 4
+                elif freq in ('f090', 'f150'):
+                    upgrade = 2
+                else:
+                    upgrade = 1
+                
+                for pidx in range(npol):
+                    plot = enplot.plot(
+                        submap[pidx], colorbar=True, ticks=5, min=vmin[pidx], max=vmax[pidx],
+                        upgrade=upgrade)
+                    enplot.write(
+                        opj(imgdir, f'coadd_SAT_{freq}_2way_set0{sidx-1}_submap_{paidx}_{pidx}'), plot)
+
+                    plot = enplot.plot(
+                        submap_sim[pidx], colorbar=True, ticks=5, min=vmin[pidx], max=vmax[pidx],
+                        upgrade=upgrade)
+                    enplot.write(
+                        opj(imgdir, f'coadd_SAT_{freq}_2way_set0{sidx-1}_submap_sim_{paidx}_{pidx}'),
+                        plot)
+
+                fmap = enmap.map2harm(submap)
+                fmap_sim = enmap.map2harm(submap_sim)
+                lmap = fmap.modlmap()
+
+                color = "1:000000,0:ffffff"
+
+                nl2d = enmap.calc_ps2d(fmap[:,None,:,:], fmap[None,:,:,:])
+
+                # Normalize to white noise floor.
+                mean_0 = np.mean(nl2d[0,0,(lmap>int(0.7*lmax)) & (lmap<int(lmax))])
+                mean_1 = np.mean(nl2d[1,1,(lmap>int(0.7*lmax)) & (lmap<int(lmax))])
+                mean_2 = np.mean(nl2d[2,2,(lmap>int(0.7*lmax)) & (lmap<int(lmax))])
+                                 
+                nl2d[0,0] /= mean_0
+                nl2d[1,1] /= mean_1
+                nl2d[2,2] /= mean_2
+
+                nl2d = enmap.lform(nl2d)
+
+                nl2d_sim = enmap.calc_ps2d(fmap_sim[:,None,:,:], fmap_sim[None,:,:,:])
+
+                # Normalize to white noise floor of TOD sim
+                nl2d_sim[0,0] /= mean_0
+                nl2d_sim[1,1] /= mean_1
+                nl2d_sim[2,2] /= mean_2
+
+                nl2d_sim = enmap.lform(nl2d_sim)
+
+                if freq in ('f030', 'f040'):
+                    ticks = 250
+                elif freq in ('f090', 'f150'):
+                    ticks = 1000
+                else:
+                    ticks = 2000
+                
+                for idx in range(3):
+                    for jdx in range(idx, 3):
+                        nl2d[idx,jdx] = ndimage.gaussian_filter(nl2d[idx,jdx], 2)
+                        nl2d_sim[idx,jdx] = ndimage.gaussian_filter(nl2d_sim[idx,jdx], 2)
+
+                        if idx != 0 and jdx != 0:
+                            lvmax = 2
+                        else:
+                            lvmax = 2.5
+                        
+                        if idx == jdx:
+                            plot = enplot.plot(np.log10(np.abs(nl2d[idx,jdx])),
+                                               colorbar=True, ticks=ticks,
+                                               max=lvmax, min=-1, color=color,
+                                               upgrade=upgrade)
+                            enplot.write(
+                                opj(imgdir,
+                                    f'coadd_SAT_{freq}_2way_set0{sidx-1}_psd_log_{paidx}_{idx}_{jdx}'),
+                                plot)
+
+                            plot = enplot.plot(np.log10(np.abs(nl2d_sim[idx,jdx])),
+                                               colorbar=True, ticks=ticks,
+                                               max=lvmax, min=-1, color=color,
+                                               upgrade=upgrade)
+                            enplot.write(opj(imgdir,
+                                    f'coadd_SAT_{freq}_2way_set0{sidx-1}_psd_log_sim_{paidx}_{idx}_{jdx}'),
+                                    plot)
+
+                        # Make sure data and sim get same color range.
+                        pvmin, pvmax = (np.quantile(nl2d[idx,jdx], 0.03), np.quantile(nl2d[idx,jdx], 0.97))
+
+                        plot = enplot.plot(nl2d[idx,jdx], colorbar=True,
+                                           ticks=ticks, min=0, max=pvmax, upgrade=upgrade)
+                        enplot.write(
+                            opj(imgdir,
+                                f'coadd_SAT_{freq}_2way_set0{sidx-1}_psd_{paidx}_{idx}_{jdx}'),
+                            plot)
+
+                        plot = enplot.plot(
+                            nl2d_sim[idx,jdx], colorbar=True,
+                            ticks=ticks, min=0, max=pvmax, upgrade=upgrade)
+                        enplot.write(opj(imgdir,
+                                f'coadd_SAT_{freq}_2way_set0{sidx-1}_psd_sim_{paidx}_{idx}_{jdx}'),
+                                plot)

--- a/mbs-s0014-20230920/plot_spectra_hp.py
+++ b/mbs-s0014-20230920/plot_spectra_hp.py
@@ -1,0 +1,77 @@
+'''
+Plot output healpix maps and compare spectra to input TOD sims.
+'''
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+
+import os
+import numpy as np
+
+opj = os.path.join
+
+mapdir = '/mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1'
+outdir = opj(mapdir, 'out', 'run00')
+imgdir = opj(mapdir, 'out/run00/img')
+specdir = opj(outdir, 'spec')
+
+freqs = ['f030', 'f040', 'f090', 'f150', 'f230', 'f290']
+npol = 3
+freq_pairs = [('f030', 'f040'), ('f090', 'f150'), ('f230', 'f290')]
+weights = ['flat', 'ivar']
+nsim = 300
+pols = ['T', 'E', 'B']
+
+for pair in freq_pairs:
+
+    for sidx in range(1, 3):
+
+        spectra_data = np.load(opj(specdir, f'spectra_{pair[0]}_{pair[1]}_set{sidx}_data.npy'))
+        spectra_sims = np.load(opj(specdir, f'spectra_{pair[0]}_{pair[1]}_set{sidx}_sims.npy'))
+        ells = np.load(opj(specdir, f'ells_{pair[0]}_{pair[1]}_set{sidx}_data.npy'))
+
+        for widx, weight in enumerate(weights):
+            for fidx1, freq1 in enumerate(pair):
+                for fidx2, freq2 in enumerate(pair):
+
+                    fig, axs = plt.subplots(ncols=3, nrows=3, dpi=300, constrained_layout=True, sharex=True)
+
+                    for aidxs, ax in np.ndenumerate(axs):
+
+                        for sim_idx in range(nsim):
+                            label = 'draws' if sim_idx == 0 else None
+                            axs[aidxs].plot(
+                                ells, spectra_sims[widx,sim_idx,fidx1,fidx2,aidxs[0],aidxs[1]],
+                                lw=0.5, color='firebrick', alpha=0.3, zorder=1, label=label)
+
+                        sim_mean = np.mean(spectra_sims[widx,:,fidx1,fidx2,aidxs[0],aidxs[1]], axis=0)
+                        sim_std = np.std(spectra_sims[widx,:,fidx1,fidx2,aidxs[0],aidxs[1]], axis=0)
+
+                        axs[aidxs].fill_between(ells, sim_mean - sim_std, sim_mean + sim_std, color='black', alpha=1,
+                                                label=r'draws $\pm 1 \sigma$')
+                        axs[aidxs].plot(ells, spectra_data[widx,fidx1,fidx2,aidxs[0],aidxs[1]],
+                                        lw=0.5, label='TOD sim')
+                        axs[aidxs].text(0.8, 1.02, f'{pols[aidxs[0]]} x {pols[aidxs[1]]}',
+                                        transform=axs[aidxs].transAxes)
+                        
+                        if aidxs[0] == aidxs[1] == 0:
+                            axs[aidxs].set_yscale('log')
+                            spec = spectra_data[widx,fidx1,fidx2,0,0]
+                            smax = np.max(spec)
+                            smin = np.min(spec[(ells > 50) & (ells < 250)])
+                            axs[aidxs].set_ylim(1e-1 * smin, 3 * smax)
+                            axs[aidxs].legend(frameon=False, loc='upper right')
+                        else:
+                            axs[aidxs].ticklabel_format(axis='y', style='sci', useOffset=False, scilimits=(0,0))
+                        axs[aidxs].set_xlim(0, 250)
+
+                    for pidx in range(3):
+                        axs[pidx,0].set_ylabel(r'$C_{\ell}$ [$\mathrm{\mu K^2}$]')
+
+                    for pidx in range(3):
+                        axs[-1,pidx].set_xlabel(r'Multipole, $\ell$')
+
+                    fig.suptitle(f'{freq1} x {freq2}, weighting : {weight}')
+                    fig.savefig(opj(imgdir,
+                            f'coadd_SAT_{freq1}_{freq2}_00{sidx}of002_spectra_{weight}_combined'))
+                    plt.close(fig)

--- a/mbs-s0014-20230920/project2car.py
+++ b/mbs-s0014-20230920/project2car.py
@@ -1,0 +1,256 @@
+'''
+Reproject the HEALPIX maps to CAR maps. Also defines "mask_obs", which 
+defindes what pixels are given to mnms.
+'''
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+
+import os
+import numpy as np
+
+import healpy as hp
+from pixell import enmap, enplot, reproject, utils, curvedsky
+from optweight import mat_utils, map_utils
+
+opj = os.path.join
+
+mapdir = '/mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1'
+imgdir = opj(mapdir, 'img_car')
+cardir = opj(mapdir, 'car')
+maskdir = opj(cardir, 'masks')
+odir = opj(mapdir, 'car')
+
+os.makedirs(imgdir, exist_ok=True)
+
+def construct_f1_geometry(box, res):
+    '''
+    Parameters
+    ----------
+    box : (2, 2) array
+        [{from,to},{dec,ra}] array giving the bottom-left and top-right corners of the desired geometry
+        in degrees.
+    res : float
+        Resolution in arcmin / pixel.
+
+    Returns
+    -------
+    shape : tuple
+        Shape of geometry.
+    wcs : astropy.wcs.WCS object
+        WCS of geometry.
+    '''
+    
+    box = np.radians(np.asarray(box))
+    shape, wcs = enmap.geometry(box, res=res * utils.arcmin, proj='CAR')
+
+    if wcs.wcs.cdelt[0] > 0:
+        raise ValueError(
+            f'By convention the X CDELT value should be negative, got : {wcs.wcs.cdelt[0]}')
+    if wcs.wcs.cdelt[1] < 0:
+        raise ValueError(
+            f'By convention the Y CDELT value should be positive, got : {wcs.wcs.cdelt[1]}')
+
+    # Check if geometry conforms to Clenshaw–Curtis. This will raise error if no quad rule can be found.
+    # This should never happen because the above always creates CC CAR maps.
+    curvedsky.get_minfo(shape, wcs, quad=True)
+
+    # Convert Clenshaw–Curtis CAR map to a Feyer1 CAR map.
+    wcs.wcs.crpix[1] -= 0.5
+
+    # Check if input map included the north pole, if so, we need to subtract one row.
+    # We do this by checking if the y pixel center of the top corner of the map has been shifted
+    # above +90 deg.
+    if np.degrees(enmap.corners(shape, wcs, corner=False))[1,0] > 90:
+        shape = (shape[0] - 1, shape[1])
+        
+    # Check if geometry conforms to Feyer1. 
+    curvedsky.get_minfo(shape, wcs, quad=True)
+
+    return shape, wcs
+
+freqs = ['f030', 'f040', 'f090', 'f150', 'f230', 'f290']
+box = np.asarray([[-75, 180],[35,-180]])
+
+# These resolution numbers are determined by taking lmax = 3 x nside
+# and then adding a factor 2 again, which is currently needed for mnmns,
+# and then adding slightly more pixels to allow for quadrature in the CAR maps.
+geom_dict = {'f030' : {'box' : box, 'res' : 40 / 3},
+             'f040' : {'box' : box, 'res' : 40 / 3},
+             'f090' : {'box' : box, 'res' : 10 / 3},
+             'f150' : {'box' : box, 'res' : 10 / 3},
+             'f230' : {'box' : box, 'res' : 5 / 3},
+             'f290' : {'box' : box, 'res' : 5 / 3}
+             }
+nside_dict = {'f030' : 128, 'f040' : 128, 'f090' : 512, 'f150' : 512, 'f230' : 1024, 'f290' : 1024}
+
+freq_pairs = [('f030', 'f040'), ('f090', 'f150'), ('f230', 'f290')]
+
+for pair in freq_pairs:
+
+    mask_obs = None
+    
+    for freq in pair:
+
+        box = geom_dict[freq]['box']
+        res = geom_dict[freq]['res']
+        
+        shape, wcs = construct_f1_geometry(box, res)
+    
+        font_size = 20 if freq in ('f030', 'f040') else 60
+
+        # Construct a CAR version of mask_obs. Masking the noisiest pixels.        
+        for sidx in range(1, 3):
+
+            icov = hp.read_map(
+                opj(mapdir, f'coadd_SAT_{freq}_00{sidx}of002_invcov.fits'),
+                field=None)
+            icov[icov == hp.UNSEEN] = 0
+            icov *= 1e-12
+
+            ivar = np.zeros((3, icov.shape[-1]), dtype=icov.dtype)
+            ivar[0] = icov[0]
+            ivar[1] = icov[3]
+            ivar[2] = icov[5]
+
+            ivar = reproject.healpix2map(ivar, shape=shape, wcs=wcs, extensive=True,
+                                                 method='spline', order=1, spin=0)
+
+            ivar_1d = ivar.reshape(3, np.prod(ivar.shape[-2:]))            
+            ivar_1d = map_utils.round_icov_matrix(ivar_1d, rtol=1e-3)
+            ivar_tr = enmap.samewcs(ivar_1d.reshape(*ivar.shape), ivar)
+
+            fig, axs = plt.subplots(dpi=300, nrows=3)
+            for pidx in range(3):
+                axs[pidx].hist(np.log10(ivar[pidx][ivar[pidx] != 0]), bins=1000)
+                axs[pidx].hist(np.log10(ivar_tr[pidx][ivar_tr[pidx] != 0]), bins=1000)
+                axs[pidx].set_yscale('log')
+            fig.savefig(opj(imgdir, f'coadd_SAT_{freq}_00{sidx}of002_ivar_hist'))
+            plt.close()
+
+            cut = ivar - ivar_tr
+            cut = cut.astype(bool)
+            cut = np.sum(cut, axis=0).astype(np.int32)
+
+            plot = enplot.plot(cut, colorbar=True, ticks=30,
+                               font_size=font_size)
+            enplot.write(opj(imgdir, f'coadd_SAT_{freq}_00{sidx}of002_cut'), plot)
+
+            if mask_obs is None:                
+                mask_obs = np.prod(ivar_tr.astype(bool), axis=0)
+            else:
+                mask_obs *= np.prod(ivar_tr.astype(bool), axis=0)
+
+    # We use a common mask between two frequencies on the same array and also I, Q, U.
+    mask_obs = mask_obs.astype(bool)
+    mask_obs = mask_obs.astype(np.float32)
+
+    plot = enplot.plot(mask_obs, colorbar=True, ticks=30,
+                       font_size=font_size)
+    enplot.write(opj(imgdir, f'coadd_SAT_{pair[0]}_{pair[1]}_mask_obs'), plot)
+                
+    enmap.write_map(opj(maskdir, f'coadd_SAT_{pair[0]}_{pair[1]}_mask_obs.fits'), mask_obs)
+
+    # Also save a HEALPix version.
+    mask_obs_hp = reproject.map2healpix(mask_obs, nside=nside_dict[freq], extensive=False,
+                                 method='spline', order=1, spin=0)
+    mask_obs_hp[mask_obs_hp < 1] = 0
+
+    fig, ax = plt.subplots(dpi=300)
+    plt.axes(ax)
+    hp.mollview(mask_obs_hp, hold=True, min=-0.5, max=1.5)
+    fig.savefig(opj(imgdir, f'coadd_SAT_{pair[0]}_{pair[1]}_mask_obs_hp.png'))
+    plt.close(fig)                
+    
+    hp.write_map(opj(maskdir, f'coadd_SAT_{pair[0]}_{pair[1]}_mask_obs_hp.fits'), mask_obs_hp,
+                 overwrite=True)
+    
+    for freq in pair:
+
+        for sidx in range(1, 3):
+
+            mapname = f'coadd_SAT_{freq}_00{sidx}of002_map'
+            imap = hp.read_map(
+                opj(mapdir, mapname + '.fits'),
+                field=None)
+            imap[imap == hp.UNSEEN] = 0            
+            imap = np.atleast_2d(imap)
+            imap *= 1e6
+            nside = hp.npix2nside(imap.shape[-1])
+            lmax = 2.5 * nside
+
+            # Load up ivar. We only do ivar, because unclear how to correctly
+            # interpolate all elements of div (i.e. they don't have well-defined
+            # spin; probably not important, but this seems safer).
+            # We alos convert all maps to uK units (input is in K).
+            ivarname = f'coadd_SAT_{freq}_00{sidx}of002_invcov'
+            ivar = hp.read_map(
+                opj(mapdir, ivarname + '.fits'),
+                field=[0])
+            ivar[ivar == hp.UNSEEN] = 0                        
+            ivar *= 1e-12
+            ivar = np.atleast_2d(ivar)
+
+            # One extensive=True ivar map to write to disk.
+            omap_ivar_ex = reproject.healpix2map(ivar, shape=shape, wcs=wcs, extensive=True,
+                                                 method='spline', order=1)
+                        
+            font_size = 20 if freq in ('f030', 'f040') else 60
+
+            # For visual comparison, reproject map using nearest-neighbor.
+            omap_spline = reproject.healpix2map(imap, shape=shape, wcs=wcs, extensive=False,
+                                                method='spline', order=0)
+
+            # Flatten map before reprojection to avoid ringing from noisy edges.
+            sqrt_ivar = mat_utils.matpow(ivar, 0.5, return_diag=True)
+            imap_flat = imap * sqrt_ivar
+
+            # Reproject weighted map.        
+            omap = reproject.healpix2map(imap_flat, shape=shape, wcs=wcs, extensive=False,
+                                         method='harm', lmax=lmax)
+
+            # Reproject the ivar. Note that we do not use extensive=True, because we
+            # also did not do that for the flattened map.
+            omap_ivar = reproject.healpix2map(ivar, shape=shape, wcs=wcs, extensive=False,
+                                              method='spline', order=1)
+
+            # Unwhiten map.
+            omap_ivar_flat = omap_ivar.reshape((1, np.prod(omap_ivar.shape[-2:])))
+            isqrt_ivar = mat_utils.matpow(omap_ivar_flat, -0.5, return_diag=True)
+            isqrt_ivar = isqrt_ivar.reshape((1,) + omap.shape[-2:])
+            omap *= isqrt_ivar                                           
+
+            # Write maps to disk. Note that we change to 0-indexing and rename invcov to ivar
+            # to make mnms extra happy. We follow the tod2map_docs recommended file formatting:
+            # https://simons1.princeton.edu/docs/tod2maps_docs/ \
+            # analysis_interface/analysis_interface_LATEST.pdf
+            mapname2write = f'coadd_SAT_{freq}_2way_set{sidx-1:02d}_map'
+            enmap.write_fits(opj(odir, f'{mapname2write}.fits'), omap)
+            ivarname2write = mapname2write.replace('map', 'ivar')
+            enmap.write_fits(opj(odir, f'{ivarname2write}.fits'), omap_ivar_ex)
+
+            # Plot maps.
+            npol = omap.shape[0]
+            tmin, tmax = (np.quantile(omap[0], 0.01), np.quantile(omap[0], 0.99))
+            pmin, pmax = (np.quantile(omap[1], 0.01), np.quantile(omap[1], 0.99))
+            vmin = [tmin, pmin, pmin]
+            vmax = [tmax, pmax, pmax]
+
+            for pidx in range(npol):
+                plot = enplot.plot(omap[pidx], colorbar=True, ticks=30, min=vmin[pidx], max=vmax[pidx],
+                                   font_size=font_size)
+                enplot.write(opj(imgdir, f'{mapname}_{pidx}'), plot)
+
+            for pidx in range(npol):
+                plot = enplot.plot(omap_spline[pidx], colorbar=True, ticks=30,
+                                   min=vmin[pidx], max=vmax[pidx],
+                                   font_size=font_size)
+                enplot.write(opj(imgdir, f'{mapname}_spline_{pidx}'), plot)
+
+            for pidx in range(npol):
+                plot = enplot.plot(omap[pidx] - omap_spline[pidx], colorbar=True, ticks=30,
+                                   min=vmin[pidx], max=vmax[pidx], font_size=font_size)
+                enplot.write(opj(imgdir, f'{mapname}_diff_{pidx}'), plot)
+
+            plot = enplot.plot(omap_ivar, colorbar=True, ticks=30)
+            enplot.write(opj(imgdir, f'{ivarname}'), plot)

--- a/mbs-s0014-20230920/project2healpix.py
+++ b/mbs-s0014-20230920/project2healpix.py
@@ -1,0 +1,218 @@
+'''
+Reproject the CAR sims to HEALPix.
+'''
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+
+import os
+import numpy as np
+import argparse
+import glob
+
+import healpy as hp
+from pixell import enmap, enplot, reproject, curvedsky, mpi as p_mpi
+from optweight import mat_utils, map_utils
+from mnms import noise_models as nm
+
+opj = os.path.join
+
+def numpy_to_mpi_type(dtype):
+    '''
+    Convert numpy dtype to MPI data_type.
+
+    Paramters
+    ---------
+    dtype : dtype
+        Numpy dtype
+
+    Returns
+    -------
+    data_type : mpi4py.MPI.Datatype
+        Corresponding MPI data type.
+    '''
+
+    # Will crash if no MPI, but OK, this function should not have been called.
+    from mpi4py import MPI
+    # Could also used mpi.util.dtlib. But was only added in mpi4py 3.1.0.
+    return MPI._typedict[np.dtype(dtype).char]
+
+def bcast_array_meta(arr, comm, root=0):
+    '''
+    Broadcast shape and dtype of array.
+
+    Parameters
+    ----------
+    arr : array, None
+        Array on root.
+    comm : MPI communicator
+    root : int, optional
+        Broadcast info from this rank.
+
+    Returns
+    -------
+    shape : tuple
+    dtype : type
+    '''
+
+    if isinstance(comm, p_mpi.FakeCommunicator) or comm.Get_size() == 1:
+        return arr.shape, arr.dtype
+
+    if comm.Get_rank() == root:
+        shape = arr.shape
+        dtype = arr.dtype
+    else:
+        shape, dtype = None, None
+
+    shape = comm.bcast(shape, root=root)
+    dtype = comm.bcast(dtype, root=root)
+
+    return shape, dtype
+
+def bcast_array(arr, comm, root=0):
+    '''
+    Broadcast array.
+
+    Parameters
+    ----------
+    arr : array
+        Array on root.
+    comm : MPI communicator
+    root : int, optional
+        Broadcast array from this rank.
+
+    Returns
+    -------
+    arr_out : array
+        Broadcasted array on all ranks.
+    '''
+
+    if isinstance(comm, p_mpi.FakeCommunicator) or comm.Get_size() == 1:
+        return arr
+
+    shape, dtype = bcast_array_meta(arr, comm, root=root)
+
+    if comm.Get_rank() != root:
+        arr = np.zeros(shape, dtype=dtype)
+
+    mpi_type = numpy_to_mpi_type(arr.dtype)
+    comm.Bcast([arr, mpi_type], root=root)
+
+    return arr
+
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+parser.add_argument('--config-name', type=str, required=True,
+                    help='Name of model config file from which to load parameters')
+parser.add_argument('--noise-model-name', dest='noise_model_name', type=str, required=True,
+                    help='Name of model within config file from which to load parameters')
+parser.add_argument('--qid', dest='qid', nargs='+', type=str, required=True,
+                    help='list of array "qids"')
+parser.add_argument('--lmax', dest='lmax', type=int, required=True,
+                    help='Bandlimit of covariance matrix.')
+parser.add_argument('--maps', dest='maps', nargs='+', type=str, default=None,
+                    help='simulate exactly these map_ids')
+parser.add_argument('--maps-start', dest='maps_start', type=int, default=None,
+                    help='like --maps, except iterate starting at this map_id')
+parser.add_argument('--maps-end', dest='maps_end', type=int, default=None,
+                    help='like --maps, except end iteration with this map_id')
+parser.add_argument('--maps-step', dest='maps_step', type=int, default=1,
+                    help='like --maps, except step iteration over map_ids by '
+                    'this number')
+parser.add_argument('--mask-obs', type=str, required=True,
+                    help='HEALPix map with mask_obs. Also determines output nside.')
+parser.add_argument('--odir', type=str, required=True,
+                    help='Output directory')
+parser.add_argument('--split-idx', type=int, required=True,
+                    help='Split index')
+parser.add_argument('--oname-template', type=str, required=True,
+                    help='A string for the output name with entries for freq, sidx and '
+                    'sim_num, e.g. '
+                    'so_sat_v1_f1_tile_{freq}_2way_set{sidx}_noise_sim_map{sim_num:04d}.fits')
+parser.add_argument('--no-mpi', action='store_true',
+                    help='Do not use MPI to compute models in parallel')
+args = parser.parse_args()
+
+if args.maps is not None:
+    assert args.maps_start is None and args.maps_end is None
+    maps = np.atleast_1d(args.maps).astype(int)
+else:
+    assert args.maps_start is not None and args.maps_end is not None
+    maps = np.arange(args.maps_start, args.maps_end+args.maps_step, args.maps_step)
+assert np.all(maps >= 0)
+
+if args.no_mpi:
+    comm = p_mpi.FakeCommunicator()
+else:
+    # Could add try statement, but better to crash if MPI cannot be imported.
+    from mpi4py import MPI
+    comm = MPI.COMM_WORLD
+
+if comm.rank == 0:
+    os.makedirs(args.odir, exist_ok=True)
+comm.Barrier()
+    
+NM = nm.BaseNoiseModel.from_config(args.config_name, args.noise_model_name, *args.qid)
+
+# Load and reproject ivar on root.
+if comm.rank == 0:
+
+    # First read expected geometry.
+    shape, wcs = enmap.read_map_geometry(
+        NM._data_model.get_map_fn(args.qid[0], split_num=args.split_idx, maptag='ivar'))
+    ivar = enmap.zeros((len(args.qid),) + shape[-2:], wcs=wcs, dtype=np.float32)
+    
+    for qidx, qid in enumerate(args.qid):
+        ivar[qidx] = enmap.read_map(
+            NM._data_model.get_map_fn(qid, split_num=args.split_idx, maptag='ivar'))
+
+    # This is ugly, but needed to compensate for upgraded ivars.
+    ivar = ivar.downgrade(2)
+    
+    mask_obs = hp.read_map(args.mask_obs)
+    nside = hp.npix2nside(mask_obs.shape[-1])
+    ivar_hp = reproject.map2healpix(ivar, nside=nside, extensive=False,
+                                    method='spline', order=1, spin=0)
+else:
+    ivar, ivar_hp, mask_obs = None, None, None
+if not args.no_mpi:
+    ivar = bcast_array(ivar, comm)
+    ivar_hp = bcast_array(ivar_hp, comm)
+    mask_obs = bcast_array(mask_obs, comm)
+
+nside = hp.npix2nside(mask_obs.shape[-1])
+# Compute square root and iverse square root of ivar for flatting.
+ivar_flat = ivar.reshape((ivar.shape[0], np.prod(ivar.shape[-2:])))
+sqrt_ivar = mat_utils.matpow(ivar_flat, 0.5, return_diag=True)
+sqrt_ivar = sqrt_ivar.reshape((ivar.shape[0],) + ivar.shape[-2:])
+del ivar_flat, ivar
+
+isqrt_ivar_hp = mat_utils.matpow(ivar_hp, -0.5, return_diag=True)
+del ivar_hp
+
+for midx in maps[comm.rank::comm.size]:
+
+    print(comm.rank, f'working on sim {midx}')
+    
+    # This contains sims for both qids.
+    imap = NM.get_sim(args.split_idx, midx, args.lmax, generate=False)[:,0,:,:,:]
+    
+    for qidx, qid in enumerate(args.qid):
+        
+        imap[qidx] *= sqrt_ivar[qidx]
+        imap_hp = reproject.map2healpix(imap[qidx], nside=nside, extensive=False,
+                                        method='harm', lmax=3 * nside, spin=[0, 2])
+        imap_hp *= isqrt_ivar_hp[qidx]
+        imap_hp *= mask_obs
+
+        # This feels a bit hacky. Just a way to convert qid to freq.
+        freq = NM._data_model.get_qid_kwargs_by_subproduct('maps', 'default', qid)['freq']
+        
+        oname = args.oname_template.format(freq=freq, sidx=args.split_idx, sim_num=midx)
+        # Convert to Kelvin.
+        imap_hp *= 1e-6
+        column_units = 'K'
+        hp.write_map(opj(args.odir, oname), imap_hp, overwrite=True, dtype=np.float32,
+                     column_units=column_units)
+
+print(comm.rank, 'done')

--- a/mbs-s0014-20230920/runs/check00
+++ b/mbs-s0014-20230920/runs/check00
@@ -1,0 +1,19 @@
+#!/bin/bash
+#SBATCH --job-name=check00
+#SBATCH --partition=cmbas
+#SBATCH --constraint=rome
+#SBATCH --nodes=1
+
+#SBATCH --ntasks-per-node=25
+#SBATCH --cpus-per-task=5
+
+#SBATCH --time=02:00:00
+
+export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
+
+module load adri_gcc
+module load adri_base
+
+source /mnt/home/aduivenvoorden/.pyenv/versions/enki/bin/activate
+
+srun -u python /mnt/home/aduivenvoorden/analysis/so/20230524_sat_noise/check_sims_hp.py

--- a/mbs-s0014-20230920/runs/run00
+++ b/mbs-s0014-20230920/runs/run00
@@ -1,0 +1,69 @@
+#!/bin/bash
+#SBATCH --job-name=run00
+#SBATCH --partition=cmbas
+#SBATCH --constraint=rome
+#SBATCH --nodes=1
+
+#SBATCH --ntasks-per-node=60
+#SBATCH --cpus-per-task=2
+
+#SBATCH --time=01:20:00
+
+export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
+
+module load adri_gcc
+module load adri_base
+
+source /mnt/home/aduivenvoorden/.pyenv/versions/enki/bin/activate
+
+TAG=run00
+MNMSDIR="/mnt/home/aduivenvoorden/local/mnms/scripts"
+SCRIPTDIR="/mnt/home/aduivenvoorden/analysis/so/20230524_sat_noise"
+SIMDIR="/mnt/home/aduivenvoorden/project/actpol/maps/mnms/sims"
+CARDIR="/mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1/car"
+ODIR="/mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1/out/${TAG}"
+
+CONFIG="so_sat_v1_f1"
+OMAP_TEMPLATE="so_sat_v1_f1_tile_{freq}_2way_set{sidx}_noise_sim_map{sim_num:04d}.fits"
+
+SIMS_END=299
+
+for FTYPE in 'lf' 'mf' 'uhf'
+do
+    if [ ${FTYPE} = 'lf' ]
+    then
+        QIDS="lfa lfb"
+	LMAX=405
+	NOISEMODEL="tile_lf"
+	declare -a FREQS=("f030" "f040")
+	MASK_OBS="${CARDIR}/masks/coadd_SAT_f030_f040_mask_obs_hp.fits"
+	NSIDE=128
+    fi
+    if [ ${FTYPE} = 'mf' ]
+    then
+        QIDS="mfa mfb"
+	LMAX=1620
+	NOISEMODEL="tile_mf"
+	declare -a FREQS=("f090" "f150")
+	MASK_OBS="${CARDIR}/masks/coadd_SAT_f090_f150_mask_obs_hp.fits"
+	NSIDE=512	
+    fi
+    if [ ${FTYPE} = 'uhf' ]
+    then
+        QIDS="uhfa uhfb"
+	LMAX=3240
+	NOISEMODEL="tile_uhf"
+	declare -a FREQS=("f230" "f290")
+	MASK_OBS="${CARDIR}/masks/coadd_SAT_f230_f290_mask_obs_hp.fits"
+	NSIDE=1024	
+    fi
+    
+    srun -u python ${MNMSDIR}/noise_gen.py --config-name ${CONFIG} --noise-model-name ${NOISEMODEL} --qid ${QIDS} --lmax ${LMAX} --use-mpi
+
+    srun -u python ${MNMSDIR}/noise_sim.py --config-name ${CONFIG} --noise-model-name ${NOISEMODEL} --qid ${QIDS} --lmax ${LMAX} --use-mpi --maps-start 0 --maps-end ${SIMS_END}
+
+    for SIDX in 0 1
+    do
+	srun -u python ${SCRIPTDIR}/project2healpix.py  --config-name ${CONFIG} --noise-model-name ${NOISEMODEL} --qid ${QIDS} --maps-start 0 --maps-end ${SIMS_END} --mask-obs ${MASK_OBS} --odir ${ODIR} --split-idx ${SIDX} --oname-template ${OMAP_TEMPLATE} --lmax ${LMAX}
+    done
+done


### PR DESCRIPTION
This PR adds an entry for the `mbs_s0014_2030920` map-based noise simulations for the SAT. These are based on the [mbs-noise-sims-sat](https://github.com/simonsobs/pwg-scripts/tree/master/pwg-tds/mbs-noise-sims-sat) time-domain simulations. Also updated the `README.md` and the `LOGBOOK.md` files with the new entry and updated the name of the slack channel in the README.