### PR TITLE
Mbs s0015 20240504

### DIFF
--- a/LOGBOOK.md
+++ b/LOGBOOK.md
@@ -2,13 +2,17 @@
 
 Date based updates from the map based simulation team
 
+## 8 Juli 2024 - Released LAT map-based noise simulations
+
+Based on the LAT time-domain ``mss0002`` mission scale simulations, using the directional wavelet noise model of [`mnms`](https://github.com/simonsobs/mnms).
+
 ## 20 Sep 2023 - Released realistic SAT map-based noise simulations
 
-Based the SAT time-domain ``mbs-noise-sims-sat`` simulations, using the tiled noise model of [`mnms`](https://github.com/simonsobs/mnms).
+Based on the SAT time-domain ``mbs-noise-sims-sat`` simulations, using the tiled noise model of [`mnms`](https://github.com/simonsobs/mnms).
 
 ## 9 May 2023 - Released realistic LAT map-based noise simulations
 
-Based the LAT time-domain `scan-s0003` simulations, using the directional wavelet noise model of [`mnms`](https://github.com/simonsobs/mnms).
+Based on the LAT time-domain `scan-s0003` simulations, using the directional wavelet noise model of [`mnms`](https://github.com/simonsobs/mnms).
 
 ## 21 March 2023 - Released MBS simulation 12
 

--- a/LOGBOOK.md
+++ b/LOGBOOK.md
@@ -2,7 +2,7 @@
 
 Date based updates from the map based simulation team
 
-## 8 Juli 2024 - Released LAT map-based noise simulations
+## 8 July 2024 - Released LAT map-based noise simulations
 
 Based on the LAT time-domain ``mss0002`` mission scale simulations, using the directional wavelet noise model of [`mnms`](https://github.com/simonsobs/mnms).
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Slack channel: `#dm-simulations`
 
 ## Available simulations
 
+* [`mbs-s0015-20240504`](mbs-s0015-20240504/README.md): Map-based noise simulations based on the LAT `mss-0002` mission scale time-domain simulations
 * [`mbs-s0014-20230920`](mbs-s0014-20230920/README.md): Map-based noise simulations based on the SAT `mbs-noise-sims-sat` time-domain simulations
 * [`mbs-s0013-20230501`](mbs-s0013-20230501/README.md): Map-based noise simulations based on the LAT `scan-s0003` time-domain simulations
 * [`mbs-s0012-20230321`](mbs-s0012-20230321/README.md): Galactic, extragalactic, CMB with realistic bandpasses.

--- a/mbs-s0015-20240504/README.md
+++ b/mbs-s0015-20240504/README.md
@@ -140,6 +140,30 @@ Finally, we can plot the sim:
 for pol in range(3):
     enplot.pshow(sim_fullres[pol], downgrade=32, colorbar=True, ticks=15)
 ```
+### Additional simulations
+
+If your analysis needs more simulations, it is possible to draw additional simulations from the provided noise models. This requires installing the [`mnms`](https://github.com/simonsobs/mnms) and [`sofind`](https://github.com/simonsobs/sofind) python libraries. Follow the "quick setup" described in the sofind readme.
+
+Loading or simulating additional maps using mnms:
+```python
+
+from mnms import noise_models as nm
+
+config_name = 'so_lat_mbs_mss0002'
+noise_model_name = 'fdw_mf' # For LF use "fdw_lf", for MF use "fdw_mf" and for UHF use "fdw_uhf"
+qids = ['mfa', 'mfb'] # Simulate f090 and f150 jointly.
+lmax = 5400
+
+model = nm.BaseNoiseModel.from_config(config_name, noise_model_name, qids)
+
+# Draw the simulation. This can be repeated for different sim_idx values.
+sim_idx = 300
+split_idx = 0 # Pick 0, 1, 2 or 3.
+sim = model.get_sim(split_idx, sim_idx, lmax, alm=False, write=False, verbose=True)
+```
+
+For an example of how to generate a larger set of simulations on a cluster, see the [run01](https://github.com/simonsobs/map_based_simulations/blob/mbs_s0015_20240504/mbs-s0015-20240504/runs/run01) script.
+For reference, drawing the simulations provided here took approximately 5 hours using 20 MPI tasks distributed over 5 128-core nodes.
 
 ## Known issues
 

--- a/mbs-s0015-20240504/README.md
+++ b/mbs-s0015-20240504/README.md
@@ -1,0 +1,145 @@
+# Map-based noise simulations based on the LAT `mss-0002` mission-scale time-domain simulations
+
+Tag: `mbs-s0015-20240504`
+
+## Updates
+
+* 2024-06-10: first release, `lmax=5400` simulations.
+
+## Summary
+
+300 realistic realizations of the LAT map noise, given the single realization of the time-domain simulations. Simulations cover the full LAT footprint to a bandlimit of `lmax=5400`, and utilize the directional wavelet noise model.
+
+## Noise model
+
+This release is based on the LAT `mss-0002` time-domain simulations, available on `NERSC` at:
+
+    /global/cfs/cdirs/sobs/sims/mss-0002/RC1.r01
+
+These time-domain simulations provide four noise splits for each frequency band. More information is available on the SO [productdb](https://www.productdb.simonsobservatory.org/product/simulation/mss-0002).
+
+Using [`mnms`](https://github.com/simonsobs/mnms), we generate 300 realizations of the noise using map-based methods. Specifically, we use the directional wavelet model, governed by the configured [parameters](parameters/so_lat_mbs_mss0002.yaml).
+
+Notes:
+* Simulations are bandlimited to `lmax=5400`. To save space, the simulations for the f090, f150, f230 and f280 bands are stored in a pixelization that is downgraded by a factor of 4 relative to the time-domain simulations (no downgrading was needed for the f030 and f040 maps) (`shape=(..., 2640, 10800)`, 2 arcmin resolution vs. `shape=(..., 10560, 43200)` 0.5 arcmin resolution). See [examples](#example-usage) below for further guidance.
+
+## Available maps
+
+Maps are available in the CAR (Fejer1 variant) pixelization. As above, the maps have a resolution of 2 arcmin. Maps are in Equatorial Coordinates, `uK_CMB` units, FITS format.
+
+The maps are located here:
+
+    /global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0015_20240504/sims
+
+and have the following naming convention:
+
+    so_lat_mbs_mss0002_fdw_{bands}_lmax5400_4way_set{split_num}_noise_sim_map{sim_num:04}.fits
+
+where `bands` is in `[lf_f030_lf_f040, mf_f090_mf_f150, uhf_f230_uhf_f290]`, `split_num` is in `[0-3]` and `sim_num` is in `[0000-0299]`.
+
+Please [open an issue here](https://github.com/simonsobs/map_based_simulations/issues/new) for any data access problems.
+
+## Available models
+
+The covariance matrices from which simulations are drawn are available here: 
+
+    /global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0015_20240504/models
+
+## Metadata
+
+The models correlate pairs of frequency bands on the same detector wafer. Therefore, the simulations are stored in a similar paired format. Thus, the shape of a given simulation file is `(2, 1, 3, 2640, 10800)`:
+* The first axis is the frequency band
+* The second (singleton) axis follows `mnms` convention (reserved for map splits; since each simulation corresponds to one map split, the dimension of this axis is 1)
+* The third axis is Stokes component (I, Q, U)
+* The last axes are the map pixels
+
+The geometry (including shape) of the maps is given in the FITS header:
+```
+SIMPLE  =                    T / conforms to FITS standard                      
+BITPIX  =                  -32 / array data type                                
+NAXIS   =
+ 5 / number of array dimensions                     
+NAXIS1  =                10800                                                  
+NAXIS2  =                 2640
+NAXIS3  =                    3                                                  
+NAXIS4  =                    1                                                  
+NAXIS5  =                    2                                                  
+WCSAXES =                    2 / Number of coordinate axes                      
+CRPIX1  =               5401.0 / Pixel coordinate of reference point            
+CRPIX2  =               1890.5 / Pixel coordinate of reference point            
+CDELT1  =   -0.033333333333333 / [deg] Coordinate increment at reference point  
+CDELT2  =    0.033333333333333 / [deg] Coordinate increment at reference point  
+CUNIT1  = 'deg'                / Units of coordinate increment and value        
+CUNIT2  = 'deg'                / Units of coordinate increment and value        
+CTYPE1  = 'RA---CAR'           / Right ascension, plate caree projection        
+CTYPE2  = 'DEC--CAR'           / Declination, plate caree projection            
+CRVAL1  =                180.0 / [deg] Coordinate value at reference point      
+CRVAL2  =                  0.0 / [deg] Coordinate value at reference point      
+LONPOLE =                  0.0 / [deg] Native longitude of celestial pole       
+LATPOLE =                 90.0 / [deg] Native latitude of celestial pole        
+MJDREF  =                  0.0 / [d] MJD of fiducial time                       
+RADESYS = 'ICRS'               / Equatorial coordinate system                   END
+```
+
+## Example usage
+
+We give some minimum working examples:
+```python
+import numpy as np
+from pixell import enmap, curvedsky, enplot
+from os.path import join
+
+# first get some basic info like the path and the filename template
+fdir = '/global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0015_20240504/sims'
+fbase_template = 'so_lat_mbs_mss0002_fdw_{bands}_lmax5400_4way_set{split_num}_noise_sim_map{sim_num:04}.fits'
+
+# let's load the sim for e.g. f150, split 2, sim 123
+bands = 'mf_f090_mf_f150'
+band_idx = 1                # f090 is 0, f150 is 1
+split_num = 2
+sim_num = 123               # has 4 digits (leading 0's), but padding done for us in template
+
+sim = enmap.read_map(
+    join(fdir, fbase_template.format(
+        bands=bands,
+        split_num=split_num,
+        sim_num=sim_num)
+        ),
+    sel=np.s_[band_idx, 0]  # just load f150, remove split axis
+    )
+print(sim.geometry, sim.dtype)
+```
+This should give:
+```python
+((3, 2640, 10800), car:{cdelt:[-0.03333,0.03333],crval:[180,0],crpix:[5400.62,1890.50]}) float32
+```
+As discussed, the `sim` only contains noise power to the Nyquist frequency of the pixelization (for 2 arcmin pixels, `lmax=5400`). But what if we wanted to work with objects in map-space defined at the full resolution of the data, for example a sky mask defined at 0.5 arcmin resolution? We need to project the `sim` to our desired geometry.
+
+Because the `sim` is bandlimited, we can do this losslessly with a spherical harmonic transforms:
+```python
+# first we need the geometry of the pixelization.
+# we can get this from one of the time-domain simulations
+shape, wcs = enmap.read_map_geometry('/global/cfs/cdirs/sobs/sims/mss-0002/RC1.r01/sobs_RC1.r01_LAT_mission_f150_4way_split1_noise_map_car.fits')
+
+# allocate an empty map to hold the sim at full resolution
+sim_fullres = enmap.empty((*sim.shape[:-2], *shape[-2:]), wcs, sim.dtype)
+
+# project sim to alm, then from alm to map
+curvedsky.alm2map(curvedsky.map2alm(sim, lmax=5400), sim_fullres)
+```
+Finally, we can plot the sim:
+```python
+# can also plot all three components in one call, but the colorbar will
+# be shared for all three plots. this is visually nicer for components
+# with very different dynamic range, as in this case
+for pol in range(3):
+    enplot.pshow(sim_fullres[pol], downgrade=32, colorbar=True, ticks=15)
+```
+
+## Known issues
+
+* Small scales (l > 4000) f030/f040 has excess noise power. Large scales (l < 1000) in f030/f040 has excess TT noise power. Large scales (l < 500) in f150 has excess TT noise power and large scales (l < 1000) in f290 has excess TT noise power. See [these slides](https://drive.google.com/file/d/1ua8AmFIUonuAgn67LnM8IgIHIxONSawP/view?usp=sharing).
+
+## Feedback
+
+If anything looks suspicious in the simulations, please do not hesitate to [open an issue here](https://github.com/simonsobs/mnms/issues/new).

--- a/mbs-s0015-20240504/README.md
+++ b/mbs-s0015-20240504/README.md
@@ -22,6 +22,9 @@ Using [`mnms`](https://github.com/simonsobs/mnms), we generate 300 realizations 
 
 Notes:
 * Simulations are bandlimited to `lmax=5400`. To save space, the simulations for the f090, f150, f230 and f280 bands are stored in a pixelization that is downgraded by a factor of 4 relative to the time-domain simulations (no downgrading was needed for the f030 and f040 maps) (`shape=(..., 2640, 10800)`, 2 arcmin resolution vs. `shape=(..., 10560, 43200)` 0.5 arcmin resolution). See [examples](#example-usage) below for further guidance.
+* The following releases were used: [`mnms v0.0.7`](https://github.com/simonsobs/mnms/tree/v0.0.7) and [`sofind v0.0.6`](https://github.com/simonsobs/sofind/tree/v0.0.6)
+* A mask has been applied to the map-domain simulations that removes a small amount of noisy pixels at the edges of the maps. The masks are stored here: `/global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0015_20240504/masks/LAT_{bands}_mask_obs.fits`.
+* See these [slides](https://drive.google.com/file/d/1ua8AmFIUonuAgn67LnM8IgIHIxONSawP/view?usp=sharing) for validation of the map-based simulations.
 
 ## Available maps
 
@@ -36,6 +39,8 @@ and have the following naming convention:
     so_lat_mbs_mss0002_fdw_{bands}_lmax5400_4way_set{split_num}_noise_sim_map{sim_num:04}.fits
 
 where `bands` is in `[lf_f030_lf_f040, mf_f090_mf_f150, uhf_f230_uhf_f290]`, `split_num` is in `[0-3]` and `sim_num` is in `[0000-0299]`.
+
+The simulations take up 2.3 TB.
 
 Please [open an issue here](https://github.com/simonsobs/map_based_simulations/issues/new) for any data access problems.
 
@@ -138,7 +143,7 @@ for pol in range(3):
 
 ## Known issues
 
-* Small scales (l > 4000) f030/f040 has excess noise power. Large scales (l < 1000) in f030/f040 has excess TT noise power. Large scales (l < 500) in f150 has excess TT noise power and large scales (l < 1000) in f290 has excess TT noise power. See [these slides](https://drive.google.com/file/d/1ua8AmFIUonuAgn67LnM8IgIHIxONSawP/view?usp=sharing).
+* Small scales (l > 4000) f030/f040 has excess noise power. Large scales (l < 1000) in f030/f040 has excess TT noise power. Large scales (l < 500) in f150 has excess TT noise power and large scales (l < 1000) in f290 has excess TT noise power. All relatively small amounts. See [these slides](https://drive.google.com/file/d/1ua8AmFIUonuAgn67LnM8IgIHIxONSawP/view?usp=sharing).
 
 ## Feedback
 

--- a/mbs-s0015-20240504/README.md
+++ b/mbs-s0015-20240504/README.md
@@ -22,7 +22,7 @@ Using [`mnms`](https://github.com/simonsobs/mnms), we generate 300 realizations 
 
 Notes:
 * Simulations are bandlimited to `lmax=5400`. To save space, the simulations for the f090, f150, f230 and f280 bands are stored in a pixelization that is downgraded by a factor of 4 relative to the time-domain simulations (no downgrading was needed for the f030 and f040 maps) (`shape=(..., 2640, 10800)`, 2 arcmin resolution vs. `shape=(..., 10560, 43200)` 0.5 arcmin resolution). See [examples](#example-usage) below for further guidance.
-* The following releases were used: [`mnms v0.0.7`](https://github.com/simonsobs/mnms/tree/v0.0.7) and [`sofind v0.0.6`](https://github.com/simonsobs/sofind/tree/v0.0.6)
+* The following releases were used: [`mnms v0.0.7`](https://github.com/simonsobs/mnms/tree/v0.0.7) and [`sofind v0.0.5`](https://github.com/simonsobs/sofind/tree/v0.0.5)
 * A mask has been applied to the map-domain simulations that removes a small amount of noisy pixels at the edges of the maps. The masks are stored here: `/global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0015_20240504/masks/LAT_{bands}_mask_obs.fits`.
 * See these [slides](https://drive.google.com/file/d/1ua8AmFIUonuAgn67LnM8IgIHIxONSawP/view?usp=sharing) for validation of the map-based simulations.
 

--- a/mbs-s0015-20240504/additional_simulations.py
+++ b/mbs-s0015-20240504/additional_simulations.py
@@ -1,0 +1,13 @@
+from mnms import noise_models as nm
+
+config_name = 'so_lat_mbs_mss0002'
+noise_model_name = 'fdw_mf' # For LF use "fdw_lf", for MF use "fdw_mf" and for UHF use "fdw_uhf"
+qids = ['mfa', 'mfb'] # Simulate f090 and f150 jointly.
+lmax = 5400
+
+model = nm.BaseNoiseModel.from_config(config_name, noise_model_name, qids)
+
+# Draw the simulation. This can be repeated for different sim_idx values.
+sim_idx = 300
+split_idx = 0 # Pick 0, 1, 2 or 3.
+sim = model.get_sim(split_idx, sim_idx, lmax, alm=False, write=False, verbose=True)

--- a/mbs-s0015-20240504/check_spectra_mpi.py
+++ b/mbs-s0015-20240504/check_spectra_mpi.py
@@ -8,10 +8,17 @@ from mnms import utils
 opj = os.path.join
 comm = MPI.COMM_WORLD
 
+# NOTE, these are paths on the CCA rusty cluster.
 imapdir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002_lat/renamed'
 simdir = '/mnt/home/aduivenvoorden/project/actpol/maps/mnms/sims'
 maskdir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002_lat/masks'
 imgdir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002_lat/compared'
+
+# Paths on NERSC would be:
+# imapdir = '/global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0015_20240504/renamed'
+# simdir = '/global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0015_20240504/sims'
+# maskdir = '/global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0015_20240504/masks'
+# imgdir = 'path/to/your/dir'
 
 os.makedirs(imgdir, exist_ok=True)
 

--- a/mbs-s0015-20240504/check_spectra_mpi.py
+++ b/mbs-s0015-20240504/check_spectra_mpi.py
@@ -1,0 +1,128 @@
+import os
+
+import numpy as np
+from mpi4py import MPI
+from pixell import enmap, curvedsky, mpi as p_mpi
+from mnms import utils
+
+opj = os.path.join
+comm = MPI.COMM_WORLD
+
+imapdir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002_lat/renamed'
+simdir = '/mnt/home/aduivenvoorden/project/actpol/maps/mnms/sims'
+maskdir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002_lat/masks'
+imgdir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002_lat/compared'
+
+os.makedirs(imgdir, exist_ok=True)
+
+freqs = [('f030', 'f040'), ('f090', 'f150'), ('f230', 'f290')]
+splits = ['split0']
+
+lmax = 5400
+ainfo = curvedsky.alm_info(lmax)
+
+npol = 3
+nell = lmax + 1
+nsim = 300
+
+def reduce_array(arr, comm, op=None, root=0):
+    '''
+    Reduce numpy array to root.
+
+    Parameters
+    ----------
+    arr : array
+    comm : MPI communicator
+    op : mpi4py.MPI.Op object, optional
+        Operation during reduce, defaults to SUM.
+    root : int, optional
+        Reduce array to this rank.
+
+    Returns
+    -------
+    arr_out : array, None
+        Reduced array on root, None on other ranks.
+    '''
+
+    if isinstance(comm, p_mpi.FakeCommunicator) or comm.Get_size() == 1:
+        return arr
+
+    if comm.Get_rank() == root:
+        arr_out = np.zeros_like(arr)
+    else:
+        arr_out = None
+
+    if op is not None:
+        comm.Reduce(arr, arr_out, op=op, root=root)
+    else:
+        comm.Reduce(arr, arr_out, root=root)
+
+    return arr_out
+
+for freq_pair in freqs:
+
+    print(comm.rank, freq_pair)
+    
+    if freq_pair == ('f030', 'f040'):
+        qstr = 'lf'
+    elif freq_pair == ('f090', 'f150'):
+        qstr = 'mf'
+    else:
+        qstr = 'uhf'
+
+    mask = enmap.read_map(
+        opj(maskdir, f'LAT_{freq_pair[0]}_{freq_pair[1]}_mask_est.fits'))
+
+    shape_dg, wcs_dg = enmap.read_map_geometry(
+        opj(simdir, f'so_lat_mbs_mss0002_fdw_{qstr}_{qstr}_{freq_pair[0]}' + \
+            f'_{qstr}_{freq_pair[1]}_lmax5400_4way_set0_noise_sim_map0000.fits'))
+
+    mask_dg = utils.fourier_resample(mask, shape=shape_dg, wcs=wcs_dg)
+    
+    for sidx, split in enumerate(splits):
+
+        spectra = np.zeros((nsim, 2, npol, 2, npol, nell))
+
+        alms = np.zeros((2, npol, ainfo.nelem), dtype=np.complex128)
+
+        if comm.rank == 0:
+
+            spectra_data = np.zeros((2, npol, 2, npol, nell))        
+            
+            for fidx, freq in enumerate(freq_pair):
+
+                imap = enmap.read_map(
+                    opj(imapdir, f'sobs_RC1.r01_LAT_mission_{freq}_4way_{split}_noise_map_car.fits'))
+
+                alms[fidx] = curvedsky.map2alm(imap * mask, ainfo=ainfo)
+
+            for fidx1 in range(2):
+                for fidx2 in range(fidx1, 2):
+                    spectra_data[fidx1,:,fidx2,:,:] = ainfo.alm2cl(
+                        alms[fidx1][:,None,:], alms[fidx2][None,:,:])
+                    
+            np.save(opj(imgdir, f'spectra_data_{qstr}'), spectra_data)                            
+
+        comm.Barrier()
+            
+        for didx in range(comm.rank,nsim,comm.size):
+
+            print(comm.rank, didx)
+
+            sim = enmap.read_map(
+                opj(simdir, f'so_lat_mbs_mss0002_fdw_{qstr}_{qstr}_{freq_pair[0]}' + \
+                    '_{qstr}_{freq_pair[1]}_lmax5400_4way_set{sidx}_noise_sim_map{didx:04d}.fits'))
+                    
+            for fidx, freq in enumerate(freq_pair):
+
+                alms[fidx] = curvedsky.map2alm(sim[fidx,0] * mask_dg, ainfo=ainfo)
+
+            for fidx1 in range(2):
+                for fidx2 in range(fidx1, 2):
+                    spectra[didx,fidx1,:,fidx2,:,:] = ainfo.alm2cl(
+                        alms[fidx1][:,None,:], alms[fidx2][None,:,:])
+
+        spectra = reduce_array(spectra, comm, op=None, root=0)
+
+        if comm.rank == 0:
+            np.save(opj(imgdir, f'spectra_sims_{qstr}'), spectra)

--- a/mbs-s0015-20240504/example_usage.py
+++ b/mbs-s0015-20240504/example_usage.py
@@ -1,0 +1,63 @@
+import numpy as np
+from pixell import enmap, curvedsky, enplot
+from os.path import join
+
+# Note, this script it set up to be run on NERSC.
+
+# first get some basic info like the path and the filename template
+fdir = '/global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0015_20240504/sims'
+fbase_template = 'so_lat_mbs_mss0002_{model}_{bands}_lmax5400_4way_set{split_num}_noise_sim_map{sim_num:04}.fits'
+
+# For models, pick from 'fdw_lf', 'fdw_mf' or 'fdw_uhf'. The corresponding entries for
+# the bands are: 'lf_f030_lf_f040', 'mf_f090_mf_f150' and uhf_f230_uhf_f290.
+
+# Let's load the sim for e.g. f150, split 2, sim 123
+model = 'fdw_mf'
+bands = 'mf_f090_mf_f150'
+band_idx = 1                # f090 is 0, f150 is 1
+split_num = 2
+sim_num = 123               # has 4 digits (leading 0's), but padding done for us in template
+
+sim = enmap.read_map(
+    join(fdir, fbase_template.format(
+        model=model,
+        bands=bands,
+        split_num=split_num,
+        sim_num=sim_num)
+        ),
+    sel=np.s_[band_idx, 0]  # just load f150, remove split axis
+    )
+print(sim.geometry, sim.dtype)
+
+assert sim.shape == (3, 2640, 10800)
+assert np.allclose(sim.wcs.wcs.cdelt, [-0.03333333, 0.03333333])
+assert np.allclose(sim.wcs.wcs.crval, [180, 0])
+assert np.allclose(sim.wcs.wcs.crpix, [5400.62, 1890.50])
+assert sim.dtype == np.float32
+
+# The sim only contains noise power to the Nyquist frequency of the pixelization (for 2 arcmin pixels, `lmax=5400`).
+# But what if we wanted to work with objects in map-space defined at the full resolution of the data, for example a
+# sky mask defined at 0.5 arcmin resolution? We need to project the `sim` to our desired geometry.
+
+# Because the `sim` is bandlimited, we can do this losslessly with a spherical harmonic transform:
+
+# First we need the geometry of the pixelization.
+# We can get this from one of the time-domain simulations
+shape, wcs = enmap.read_map_geometry(
+    '/global/cfs/cdirs/sobs/sims/mss-0002/RC1.r01/sobs_RC1.r01_LAT_mission_f150_4way_split1_noise_map_car.fits')
+
+# Allocate an empty map to hold the sim at full resolution
+sim_fullres = enmap.empty((*sim.shape[:-2], *shape[-2:]), wcs, sim.dtype)
+
+# Project sim to alm, then from alm to map
+
+# High res vesion:
+#curvedsky.alm2map(curvedsky.map2alm(sim, lmax=5400), sim_fullres)
+
+# Low res version for quick testing:
+curvedsky.alm2map(curvedsky.map2alm(sim, lmax=300), sim_fullres)
+
+# Finally, we can plot the sim:
+for pol in range(3):
+    plot = enplot.plot(sim_fullres[pol], downgrade=32, colorbar=True, ticks=15)
+    enplot.write(f'example_plot_{pol}', plot)

--- a/mbs-s0015-20240504/example_usage.py
+++ b/mbs-s0015-20240504/example_usage.py
@@ -1,5 +1,6 @@
 from packaging.version import Version
 import numpy as np
+import pixell
 from pixell import enmap, curvedsky, enplot
 from os.path import join
 
@@ -60,7 +61,9 @@ sim_fullres = enmap.empty((*sim.shape[:-2], *shape[-2:]), wcs, sim.dtype)
 # Low res version for quick testing:
 curvedsky.alm2map(curvedsky.map2alm(sim, lmax=300), sim_fullres)
 
-# Finally, we can plot the sim:
-for pol in range(3):
-    plot = enplot.plot(sim_fullres[pol], downgrade=32, colorbar=True, ticks=15)
+# Finally, we can save plots of the I, Q and U components of the simulated map as png files.
+# Note that if you are working in an interactive notebook, you can replace the
+# "enplot.plot" and "enplot.write" calls with "enplot.pshow" to just show the plots.
+for pidx, pol in enumerate(['I', 'Q', 'U']):
+    plot = enplot.plot(sim_fullres[pidx], downgrade=32, colorbar=True, ticks=15)
     enplot.write(f'example_plot_{pol}', plot)

--- a/mbs-s0015-20240504/example_usage.py
+++ b/mbs-s0015-20240504/example_usage.py
@@ -1,6 +1,9 @@
+from packaging.version import Version
 import numpy as np
 from pixell import enmap, curvedsky, enplot
 from os.path import join
+
+assert Version(pixell.__version__) >= Version('0.19'), "We require pixell version > 0.19 (change from libsharp to ducc)"
 
 # Note, this script it set up to be run on NERSC.
 

--- a/mbs-s0015-20240504/make_masks.py
+++ b/mbs-s0015-20240504/make_masks.py
@@ -9,8 +9,14 @@ from pixell import enmap, enplot
 comm = MPI.COMM_WORLD
 opj = os.path.join
 
+# NOTE, these are paths on the CCA rusty cluster.
 idir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002/RC1.r01'
 odir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002_lat/masks'
+
+# Paths on NERSC would be:
+# idir = '/global/cfs/cdirs/sobs/sims/mss-0002/RC1.r01'
+# odir = '/global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0015_20240504/masks'
+
 imgdir = opj(odir, 'img')
 
 if comm.rank == 0:

--- a/mbs-s0015-20240504/make_masks.py
+++ b/mbs-s0015-20240504/make_masks.py
@@ -1,0 +1,73 @@
+import os
+
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.stats import median_abs_deviation
+from mpi4py import MPI
+from pixell import enmap, enplot
+
+comm = MPI.COMM_WORLD
+opj = os.path.join
+
+idir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002/RC1.r01'
+odir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002_lat/masks'
+imgdir = opj(odir, 'img')
+
+if comm.rank == 0:
+    os.makedirs(imgdir, exist_ok=True)
+
+freqs = [('f030', 'f040'), ('f090', 'f150'), ('f230', 'f290')]
+splits = ['split0', 'split1', 'split2', 'split3']
+
+for freq_pair in freqs[comm.rank::comm.size]:
+
+    shape, wcs = enmap.read_map_geometry(
+        opj(idir, f'sobs_RC1.r01_LAT_mission_{freq_pair[0]}_4way_split0_sky_ivar_car.fits'))
+
+    mask_obs = enmap.ones(shape, wcs=wcs, dtype=bool)
+
+    for freq in freq_pair:
+
+        fig, ax = plt.subplots(dpi=300)
+
+        for sidx, split in enumerate(splits):
+            ivarname = f'sobs_RC1.r01_LAT_mission_{freq}_4way_{split}_sky_ivar_car'
+            ivar = enmap.read_map(opj(idir, f'{ivarname}.fits'))
+
+            ivar_nonzero = ivar[ivar != 0]
+            median = np.median(ivar_nonzero)
+
+            lower_cut = 1e-3 * median
+
+            ax.hist(np.log10(ivar[ivar != 0]), bins=1000, color=f'C{sidx}',
+                    histtype='step')
+
+            ax.axvline(np.log10(lower_cut), color=f'C{sidx}')
+
+            mask_obs *= ivar >= lower_cut
+                
+        ax.set_xlabel('log ivar')
+        ax.set_yscale('log')
+        fig.savefig(opj(imgdir, f'hist_{freq}'))
+        plt.close(fig)
+
+    plot = enplot.plot(mask_obs, downgrade=4, colorbar=True, ticks=30)
+    enplot.write(opj(imgdir, f'LAT_{freq_pair[0]}_{freq_pair[1]}_mask_obs'), plot)
+
+    if freq_pair == ('f030', 'f040'):
+        
+        mask_obs = enmap.upgrade(mask_obs, 2)
+    
+    # Save mask obs
+    enmap.write_map(opj(odir, f'LAT_{freq_pair[0]}_{freq_pair[1]}_mask_obs.fits'),
+                    mask_obs.astype(np.float32))
+    
+    # Create mask est
+    mask_est = enmap.shrink_mask(mask_obs, np.radians(1))
+    mask_est = enmap.apod_mask(mask_est.astype(np.float32), width=np.radians(1))
+
+    enmap.write_map(opj(odir, f'LAT_{freq_pair[0]}_{freq_pair[1]}_mask_est.fits'),
+                    mask_est)
+    
+    plot = enplot.plot(mask_est, downgrade=4, colorbar=True, ticks=30)
+    enplot.write(opj(imgdir, f'LAT_{freq_pair[0]}_{freq_pair[1]}_mask_est'), plot)    

--- a/mbs-s0015-20240504/parameters/so_lat_mbs_mss0002.yaml
+++ b/mbs-s0015-20240504/parameters/so_lat_mbs_mss0002.yaml
@@ -1,0 +1,285 @@
+system_paths:
+  perlmutter: /global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0015_20240504
+  rusty: /mnt/home/aduivenvoorden/project/so/20240504_mss0002_lat
+
+allowed_qids_configs:
+- so_basic_qids.yaml
+
+allowed_qids: 'all'
+
+allowed_qids_extra_kwargs:
+  lfa:
+    num_splits: 4
+
+  lfb:
+    num_splits: 4
+
+  mfa:
+    num_splits: 4
+
+  mfb:
+    num_splits: 4
+
+  uhfa:
+    num_splits: 4
+
+  uhfb:
+    num_splits: 4
+
+fdw_lf:
+  noise_model_class: FDW
+  data_model_name: so_lat_mbs_mss0002
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: default
+  calibrated: false
+  catalogs_subproduct: null
+  catalog_name: null
+  differenced: false
+  dtype: f4
+  enforce_equal_qid_kwargs:
+  - array
+  - num_splits
+  filter_kwargs:
+    lim: 0.000001
+    lim0: null
+    post_filt_rel_downgrade: 2
+    ell_lows:
+      - 100
+    ell_highs:
+      - 200
+    profile: cosine
+  iso_filt_method: harmonic
+  ivar_filt_method: scaledep
+  ivar_fwhms:
+    - 15
+    - 15
+  ivar_lmaxs:
+    - 100
+    - null
+  kfilt_lbounds: null
+  masks_subproduct: so_lat_mbs_mss0002_masks
+  mask_est_name: LAT_f030_f040_mask_est.fits
+  mask_est_edgecut: 0
+  mask_est_apodization: 180
+  mask_obs_name: LAT_f030_f040_mask_obs.fits
+  mask_obs_edgecut: 0
+  model_lim: 0.000001
+  model_lim0: null
+  qid_names_template: '{array}_{freq}'
+  srcfree: false
+  fwhm_fact_pt1:
+  - 1350
+  - 10.0
+  fwhm_fact_pt2:
+  - 5400
+  - 16.0
+  kern_cut: 0.0001
+  lamb: 1.6
+  n: 36
+  nback:
+  - 0
+  nforw:
+  - 0
+  - 6
+  - 6
+  - 6
+  - 6
+  - 12
+  - 12
+  - 12
+  - 12
+  - 24
+  - 24
+  p: 2
+  pback:
+  - 0
+  pforw:
+  - 0
+  - 6
+  - 4
+  - 2
+  - 2
+  - 12
+  - 8
+  - 4
+  - 2
+  - 12
+  - 8
+  w_lmax: 10800
+  w_lmax_j: 5300
+  w_lmin: 10
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'
+
+fdw_mf:
+  noise_model_class: FDW
+  data_model_name: so_lat_mbs_mss0002
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: default
+  calibrated: false
+  catalogs_subproduct: null
+  catalog_name: null
+  differenced: false
+  dtype: f4
+  enforce_equal_qid_kwargs:
+  - array
+  - num_splits
+  filter_kwargs:
+    lim: 0.000001
+    lim0: null
+    post_filt_rel_downgrade: 2
+    ell_lows:
+      - 100
+    ell_highs:
+      - 200
+    profile: cosine
+  iso_filt_method: harmonic
+  ivar_filt_method: scaledep
+  ivar_fwhms:
+    - 15
+    - 15
+  ivar_lmaxs:
+    - 100
+    - null
+  kfilt_lbounds: null
+  masks_subproduct: so_lat_mbs_mss0002_masks
+  mask_est_name: LAT_f090_f150_mask_est.fits
+  mask_est_edgecut: 0
+  mask_est_apodization: 180
+  mask_obs_name: LAT_f090_f150_mask_obs.fits
+  mask_obs_edgecut: 0
+  model_lim: 0.000001
+  model_lim0: null
+  qid_names_template: '{array}_{freq}'
+  srcfree: false
+  fwhm_fact_pt1:
+  - 1350
+  - 10.0
+  fwhm_fact_pt2:
+  - 5400
+  - 16.0
+  kern_cut: 0.0001
+  lamb: 1.6
+  n: 36
+  nback:
+  - 0
+  nforw:
+  - 0
+  - 6
+  - 6
+  - 6
+  - 6
+  - 12
+  - 12
+  - 12
+  - 12
+  - 24
+  - 24
+  p: 2
+  pback:
+  - 0
+  pforw:
+  - 0
+  - 6
+  - 4
+  - 2
+  - 2
+  - 12
+  - 8
+  - 4
+  - 2
+  - 12
+  - 8
+  w_lmax: 10800
+  w_lmax_j: 5300
+  w_lmin: 10
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'
+  
+fdw_uhf:
+  noise_model_class: FDW
+  data_model_name: so_lat_mbs_mss0002
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: default
+  calibrated: false
+  catalogs_subproduct: null
+  catalog_name: null
+  differenced: false
+  dtype: f4
+  enforce_equal_qid_kwargs:
+  - array
+  - num_splits
+  filter_kwargs:
+    lim: 0.000001
+    lim0: null
+    post_filt_rel_downgrade: 2
+    ell_lows:
+      - 100
+    ell_highs:
+      - 200
+    profile: cosine
+  iso_filt_method: harmonic
+  ivar_filt_method: scaledep
+  ivar_fwhms:
+    - 15
+    - 15
+  ivar_lmaxs:
+    - 100
+    - null
+  kfilt_lbounds: null
+  masks_subproduct: so_lat_mbs_mss0002_masks
+  mask_est_name: LAT_f230_f290_mask_est.fits
+  mask_est_edgecut: 0
+  mask_est_apodization: 180
+  mask_obs_name: LAT_f230_f290_mask_obs.fits
+  mask_obs_edgecut: 0
+  model_lim: 0.000001
+  model_lim0: null
+  qid_names_template: '{array}_{freq}'
+  srcfree: false
+  fwhm_fact_pt1:
+  - 1350
+  - 10.0
+  fwhm_fact_pt2:
+  - 5400
+  - 16.0
+  kern_cut: 0.0001
+  lamb: 1.6
+  n: 36
+  nback:
+  - 0
+  nforw:
+  - 0
+  - 6
+  - 6
+  - 6
+  - 6
+  - 12
+  - 12
+  - 12
+  - 12
+  - 24
+  - 24
+  p: 2
+  pback:
+  - 0
+  pforw:
+  - 0
+  - 6
+  - 4
+  - 2
+  - 2
+  - 12
+  - 8
+  - 4
+  - 2
+  - 12
+  - 8
+  w_lmax: 10800
+  w_lmax_j: 5300
+  w_lmin: 10
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'

--- a/mbs-s0015-20240504/plot_maps.py
+++ b/mbs-s0015-20240504/plot_maps.py
@@ -1,0 +1,43 @@
+import os
+
+import numpy as np
+from mpi4py import MPI
+from pixell import enmap, enplot
+
+comm = MPI.COMM_WORLD
+opj = os.path.join
+
+idir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002/RC1.r01'
+imgdir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002_lat/input/img'
+
+if comm.rank == 0:
+    os.makedirs(imgdir, exist_ok=True)
+
+freqs = ['f030', 'f040', 'f090', 'f150', 'f230', 'f290']
+splits = ['coadd', 'split0', 'split1', 'split2', 'split3']
+
+freqs_splits = []
+
+for freq in freqs:    
+    for split in splits:
+        freqs_splits.append((freq, split))
+
+for freq, split in freqs_splits[comm.rank::comm.size]:
+
+    mapname = f'sobs_RC1.r01_LAT_mission_{freq}_4way_{split}_noise_map_car'
+    imap = enmap.read_map(opj(idir, f'{mapname}.fits'))
+
+    plot = enplot.plot(imap[0], downgrade=8, font_size=50, ticks=30, colorbar=True)
+    enplot.write(opj(imgdir, f'{mapname}_0'), plot)    
+    for pidx in range(1, 3):
+        plot = enplot.plot(imap[pidx], downgrade=8, font_size=50, ticks=30, colorbar=True)
+        enplot.write(opj(imgdir, f'{mapname}_{pidx}'), plot)
+
+    del imap
+    
+    ivarname = f'sobs_RC1.r01_LAT_mission_{freq}_4way_{split}_sky_ivar_car'
+    ivar = enmap.read_map(opj(idir, f'{ivarname}.fits'))
+
+    plot = enplot.plot(ivar, downgrade=8, font_size=50, ticks=30, colorbar=True)
+    enplot.write(opj(imgdir, ivarname), plot)
+    

--- a/mbs-s0015-20240504/plot_maps.py
+++ b/mbs-s0015-20240504/plot_maps.py
@@ -7,8 +7,13 @@ from pixell import enmap, enplot
 comm = MPI.COMM_WORLD
 opj = os.path.join
 
+# NOTE, these are paths on the CCA rusty cluster.
 idir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002/RC1.r01'
 imgdir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002_lat/input/img'
+
+# Paths on NERSC would be:
+# idir = '/global/cfs/cdirs/sobs/sims/mss-0002/RC1.r01'
+# imgdir = 'your/own/path'
 
 if comm.rank == 0:
     os.makedirs(imgdir, exist_ok=True)

--- a/mbs-s0015-20240504/preprocess_maps.py
+++ b/mbs-s0015-20240504/preprocess_maps.py
@@ -1,0 +1,62 @@
+'''
+Rename the maps and additionally, resample the LF maps to 2x the resolution.
+This is needed for mnms. 
+'''
+
+import os
+
+import numpy as np
+from pixell import enmap, enplot
+from mnms import utils
+
+opj = os.path.join
+
+idir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002/RC1.r01'
+odir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002_lat/renamed'
+os.makedirs(odir, exist_ok=True)
+
+freqs = ['f030', 'f040', 'f090', 'f150', 'f230', 'f290']
+splits = ['split0', 'split1', 'split2', 'split3']
+
+freqs_splits = []
+
+for freq in freqs:    
+    for split in splits:
+        freqs_splits.append((freq, split))
+
+for freq, split in freqs_splits:
+
+    mapname_in = f'sobs_RC1.r01_LAT_mission_{freq}_4way_{split}_noise_map_car.fits'
+    mapname_out = f'sobs_RC1.r01_LAT_mission_{freq}_4way_{split}_noise_map_car.fits'    
+    
+    ivarname_in = f'sobs_RC1.r01_LAT_mission_{freq}_4way_{split}_sky_ivar_car.fits'
+    ivarname_out = f'sobs_RC1.r01_LAT_mission_{freq}_4way_{split}_noise_ivar_car.fits'    
+
+    if freq in ['f030', 'f040']:
+        
+        shape, wcs = enmap.read_map_geometry(opj(idir, mapname_in))
+
+        assert utils.get_variant(shape, wcs, atol=1e-6) == 'fejer1'
+        
+        shape_ug, wcs_ug = enmap.upgrade_geometry(shape, wcs, 2)
+        imap = enmap.read_map(opj(idir, mapname_in))
+        omap = utils.fourier_resample(imap, shape=(shape[0],) + shape_ug[-2:], wcs=wcs_ug)
+        enmap.write_map(opj(odir, mapname_out), omap)
+        del omap, imap
+
+        ivar = enmap.read_map(opj(idir, ivarname_in))
+        ivar = enmap.upgrade(ivar, 2) / 4 # Correction for change in pixel size.
+        enmap.write_map(opj(odir, ivarname_out), ivar)        
+        
+    else:
+        try:
+            os.symlink(opj(idir, mapname_in), opj(odir, mapname_out))
+        except FileExistsError as e:
+            os.remove(opj(odir, mapname_out))
+            os.symlink(opj(idir, mapname_in), opj(odir, mapname_out))
+
+        try:            
+            os.symlink(opj(idir, ivarname_in), opj(odir, ivarname_out))
+        except FileExistsError as e:
+            os.remove(opj(odir, ivarname_out))
+            os.symlink(opj(idir, ivarname_in), opj(odir, ivarname_out))

--- a/mbs-s0015-20240504/preprocess_maps.py
+++ b/mbs-s0015-20240504/preprocess_maps.py
@@ -11,8 +11,14 @@ from mnms import utils
 
 opj = os.path.join
 
+# NOTE, these are paths on the CCA rusty cluster.
 idir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002/RC1.r01'
 odir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002_lat/renamed'
+
+# Paths on NERSC would be:
+# idir = '/global/cfs/cdirs/sobs/sims/mss-0002/RC1.r01'
+# odir = '/global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0015_20240504/renamed'
+
 os.makedirs(odir, exist_ok=True)
 
 freqs = ['f030', 'f040', 'f090', 'f150', 'f230', 'f290']

--- a/mbs-s0015-20240504/runs/README
+++ b/mbs-s0015-20240504/runs/README
@@ -1,0 +1,2 @@
+run00	testing
+run01	300 sims

--- a/mbs-s0015-20240504/runs/run00
+++ b/mbs-s0015-20240504/runs/run00
@@ -1,0 +1,53 @@
+#!/bin/bash
+##SBATCH --job-name=run00
+##SBATCH --partition=cmbas
+##SBATCH --constraint=rome
+##SBATCH --nodes=1
+
+##SBATCH --ntasks-per-node=60
+##SBATCH --cpus-per-task=2
+
+##SBATCH --time=01:20:00
+
+#export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
+export OMP_NUM_THREADS=20
+
+module load adri_gcc
+module load adri_base
+
+source /mnt/home/aduivenvoorden/.pyenv/versions/enki/bin/activate
+
+TAG=run00
+MNMSDIR="/mnt/home/aduivenvoorden/local/mnms/scripts"
+
+CONFIG="so_lat_mbs_mss0002"
+LMAX=5400
+
+SIMS_END=1
+
+#for FTYPE in 'lf' 'mf' 'uhf'
+for FTYPE in 'uhf'
+do
+    if [ ${FTYPE} = 'lf' ]
+    then
+        QIDS="lfa lfb"
+	NOISEMODEL="fdw_lf"
+    fi
+    if [ ${FTYPE} = 'mf' ]
+    then
+        QIDS="mfa mfb"
+	NOISEMODEL="fdw_mf"
+    fi
+    if [ ${FTYPE} = 'uhf' ]
+    then
+        QIDS="uhfa uhfb"
+	NOISEMODEL="fdw_uhf"
+    fi
+    
+    #srun -u python ${MNMSDIR}/noise_gen.py --config-name ${CONFIG} --noise-model-name ${NOISEMODEL} --qid ${QIDS} --lmax ${LMAX} --use-mpi
+    #srun -u python ${MNMSDIR}/noise_sim.py --config-name ${CONFIG} --noise-model-name ${NOISEMODEL} --qid ${QIDS} --lmax ${LMAX} --use-mpi --maps-start 0 --maps-end ${SIMS_END}
+
+    srun -u -n 2 python ${MNMSDIR}/noise_gen.py --config-name ${CONFIG} --noise-model-name ${NOISEMODEL} --qid ${QIDS} --lmax ${LMAX} --use-mpi
+    srun -u -n 2 python ${MNMSDIR}/noise_sim.py --config-name ${CONFIG} --noise-model-name ${NOISEMODEL} --qid ${QIDS} --lmax ${LMAX} --use-mpi --maps-start 0 --maps-end ${SIMS_END}
+
+done

--- a/mbs-s0015-20240504/runs/run01
+++ b/mbs-s0015-20240504/runs/run01
@@ -1,0 +1,46 @@
+#!/bin/bash
+#SBATCH --job-name=run01
+#SBATCH --partition=cmbas
+#SBATCH --constraint=rome
+#SBATCH --nodes=5
+#SBATCH --ntasks-per-node=4
+#SBATCH --cpus-per-task=32
+#SBATCH --time=05:00:00
+
+export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
+
+module load adri_gcc
+module load adri_base
+
+source /mnt/home/aduivenvoorden/.pyenv/versions/enki/bin/activate
+
+TAG=run01
+MNMSDIR="/mnt/home/aduivenvoorden/local/mnms/scripts"
+
+CONFIG="so_lat_mbs_mss0002"
+LMAX=5400
+
+SIMS_END=299
+
+for FTYPE in 'lf' 'mf' 'uhf'
+do
+    if [ ${FTYPE} = 'lf' ]
+    then
+        QIDS="lfa lfb"
+	NOISEMODEL="fdw_lf"
+    fi
+    if [ ${FTYPE} = 'mf' ]
+    then
+        QIDS="mfa mfb"
+	NOISEMODEL="fdw_mf"
+    fi
+    if [ ${FTYPE} = 'uhf' ]
+    then
+        QIDS="uhfa uhfb"
+	NOISEMODEL="fdw_uhf"
+    fi
+    
+    srun -u --cpu-bind=cores -c $SLURM_CPUS_PER_TASK python ${MNMSDIR}/noise_gen.py --config-name ${CONFIG} --noise-model-name ${NOISEMODEL} --qid ${QIDS} --lmax ${LMAX} --use-mpi
+    srun -u --cpu-bind=cores -c $SLURM_CPUS_PER_TASK python ${MNMSDIR}/noise_sim.py --config-name ${CONFIG} --noise-model-name ${NOISEMODEL} --qid ${QIDS} --lmax ${LMAX} --use-mpi --maps-start 0 --maps-end ${SIMS_END}
+
+done

--- a/plot_spectra.py
+++ b/plot_spectra.py
@@ -1,0 +1,89 @@
+import os
+import time
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+opj = os.path.join
+
+imgdir = '/mnt/home/aduivenvoorden/project/so/20240504_mss0002_lat/compared'
+
+freqs = [('f030', 'f040'), ('f090', 'f150'), ('f230', 'f290')]
+splits = ['split0']
+
+lmax = 5400
+
+npol = 3
+nell = lmax + 1
+nsim = 300
+pols = ['T', 'E', 'B']
+
+ells = np.arange(nell)
+
+for pair in freqs:
+    
+    if pair == ('f030', 'f040'):
+        qstr = 'lf'
+    elif pair == ('f090', 'f150'):
+        qstr = 'mf'
+    else:
+        qstr = 'uhf'
+    
+    for sidx, split in enumerate(splits):
+
+        spectra_data = np.load(opj(imgdir, f'spectra_data_{qstr}.npy'))
+        spectra_sims = np.load(opj(imgdir, f'spectra_sims_{qstr}.npy'))
+        
+        for fidx1, freq1 in enumerate(pair):
+            for fidx2, freq2 in enumerate(pair):
+
+                if fidx2 < fidx1:
+                    continue
+                
+                fig, axs = plt.subplots(ncols=3, nrows=3, dpi=300, constrained_layout=True, sharex=True,
+                                        figsize=(10, 10))
+
+                for aidxs, ax in np.ndenumerate(axs):
+
+                    for sim_idx in range(nsim):
+                        label = 'draws' if sim_idx == 0 else None
+                        axs[aidxs].plot(
+                            ells, spectra_sims[sim_idx,fidx1,aidxs[0],fidx2,aidxs[1]],
+                            lw=0.5, color='firebrick', alpha=0.3, zorder=1, label=label)
+
+                    sim_mean = np.mean(spectra_sims[:,fidx1,aidxs[0],fidx2,aidxs[1]], axis=0)
+                    sim_std = np.std(spectra_sims[:,fidx1,aidxs[0],fidx2,aidxs[1]], axis=0)
+
+                    axs[aidxs].fill_between(ells, sim_mean - sim_std, sim_mean + sim_std, color='black', alpha=1,
+                                            label=r'draws $\pm 1 \sigma$')
+                    axs[aidxs].plot(ells, spectra_data[fidx1,aidxs[0],fidx2,aidxs[1]],
+                                    lw=0.5, label='TOD sim')
+                    axs[aidxs].text(0.8, 1.02, f'{pols[aidxs[0]]} x {pols[aidxs[1]]}',
+                                    transform=axs[aidxs].transAxes)
+
+                    if aidxs[0] == aidxs[1]:
+                        if fidx1 == fidx2:
+                            axs[aidxs].set_yscale('log')
+                        #else:
+                        #    axs[aidxs].set_yscale('symlog', linthresh=1e-4)
+                        spec = spectra_data[fidx1,0,fidx2,0]
+                        #smax = np.max(spec)
+                        #smin = np.min(spec[(ells > 50) & (ells < 250)])
+                        #axs[aidxs].set_ylim(1e-1 * smin, 3 * smax)
+                        axs[aidxs].legend(frameon=False, loc='upper right')
+                    else:
+                        axs[aidxs].ticklabel_format(axis='y', style='sci', useOffset=False, scilimits=(0,0))
+                    axs[aidxs].set_xlim(1, 5000)
+                    axs[aidxs].set_xscale('log')
+
+                for pidx in range(3):
+                    axs[pidx,0].set_ylabel(r'$C_{\ell}$ [$\mathrm{\mu K^2}$]')
+
+                for pidx in range(3):
+                    axs[-1,pidx].set_xlabel(r'Multipole, $\ell$')
+
+                fig.suptitle(f'{freq1} x {freq2}')
+                fig.savefig(opj(imgdir, f'so_lat_mbs_mss0002_fdw_{freq1}_{freq2}_set{sidx}_spectra'))
+                                
+                plt.close(fig)
+        


### PR DESCRIPTION
This PR adds an entry for the mbs_s0015_20240504 map-based noise simulations for the LAT. These are based on the mss0002 mission-scale time-domain simulations. Also updated the README.md and the LOGBOOK.md files with the new entry.